### PR TITLE
refactor: integrate spatie roles

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -32,14 +32,11 @@ class AuthenticatedSessionController extends Controller
         if (Auth::attempt($request->only('email', 'password'), $request->boolean('remember'))) {
             $request->session()->regenerate();
 
-            $role = Auth::user()->rol;
-
-            switch ($role) {
-                case 'promotor':
-                    return redirect()->intended('/mobile');
-                default:
-                    return redirect()->intended('/dashboard');
+            if (Auth::user()->hasRole('promotor')) {
+                return redirect()->intended('/mobile');
             }
+
+            return redirect()->intended('/dashboard');
         }
 
         return back()->withErrors([

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -24,11 +24,11 @@ class UserController extends Controller
             'name' => $validated['name'],
             'email' => $validated['email'],
             'password' => Hash::make($validated['password']),
-            'rol' => $validated['rol'],
             'telefono' => $validated['telefono'],
         ]);
 
         event(new Registered($user));
+        $user->assignRole($validated['rol']);
 
         return redirect()
             ->route('admin.empleados.create')

--- a/app/Http/Middleware/ShareRole.php
+++ b/app/Http/Middleware/ShareRole.php
@@ -9,7 +9,7 @@ class ShareRole
 {
     public function handle(Request $request, Closure $next)
     {
-        view()->share('role', optional($request->user())->rol);
+        view()->share('role', optional($request->user())->getRoleNames()->first());
         return $next($request);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.
@@ -21,7 +22,6 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'rol', // Default role for the user
         'telefono', // User's phone number
     ];
 
@@ -48,23 +48,4 @@ class User extends Authenticatable
         ];
     }
 
-    /**
-     * Determina si el usuario tiene rol de promotor.
-     *
-     * @return bool
-     */
-    public function isPromotor(): bool
-    {
-        return $this->rol === 'promotor';
-    }
-
-    public function isSupervisor(): bool
-    {
-        return $this->rol === 'supervisor';
-    }
-
-    public function isEjecutivo(): bool
-    {
-        return $this->rol === 'ejecutivo';
-    }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -23,16 +24,22 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
-        $roles = ['promotor', 'administrador', 'supervisor', 'ejecutivo', 'superadmin'];
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
-            'rol' => fake()->randomElement($roles), // Default role for the user,
             'telefono' => fake()->numerify('##########'), // User's phone number,
             'remember_token' => Str::random(10),
         ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (User $user) {
+            $roles = ['promotor', 'administrador', 'supervisor', 'ejecutivo', 'superadmin'];
+            $user->assignRole($roles[array_rand($roles)]);
+        });
     }
 
     /**

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -18,7 +18,6 @@ return new class extends Migration
             $table->string('telefono', 10);
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->string('rol')->default('promotor');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,43 +19,43 @@ class DatabaseSeeder extends Seeder
         $roles = ['promotor', 'administrador', 'supervisor', 'ejecutivo', 'superadmin'];
 
         foreach (range(1, 20) as $index) {
-            User::factory()->create([
-                'rol' => $roles[array_rand($roles)],
+            $user = User::factory()->create([
                 'password' => Hash::make('Password123'),
             ]);
+            $user->assignRole($roles[array_rand($roles)]);
         }
 
         // Usuarios específicos
-        User::factory()->create([
+        $user = User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('Password123'),
-            'rol' => 'superadmin',
             'telefono' => '1234567890',
         ]);
+        $user->assignRole('superadmin');
 
-        User::factory()->create([
+        $user = User::factory()->create([
             'name' => 'Promotor User',
             'email' => 'promotor@example.com',
             'password' => Hash::make('Password123'),
-            'rol' => 'promotor',
             'telefono' => '0987654321',
         ]);
+        $user->assignRole('promotor');
 
-        User::factory()->create([
+        $user = User::factory()->create([
             'name' => 'Supervisor User',
             'email' => 'supervisor@example.com',
             'password' => Hash::make('Password123'),
-            'rol' => 'supervisor',
             'telefono' => '0987654321',
         ]);
+        $user->assignRole('supervisor');
 
-        User::factory()->create([
+        $user = User::factory()->create([
             'name' => 'Ejecutivo User',
             'email' => 'ejecutivo@example.com',
             'password' => Hash::make('Password123'),
-            'rol' => 'ejecutivo',
             'telefono' => '0987654321',
         ]);
+        $user->assignRole('ejecutivo');
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,8 +19,8 @@ use App\Http\Middleware\ShareRole;
 */
 
 Route::get('/', function () {
-    // if (Auth::check() && Auth::user()->rol === 'promotor') {
-    if (Auth::check() && in_array(Auth::user()->rol, ['promotor', 'supervisor', 'ejecutivo'])) {
+    // if (Auth::check() && Auth::user()->hasRole('promotor')) {
+    if (Auth::check() && Auth::user()->hasAnyRole(['promotor', 'supervisor', 'ejecutivo'])) {
         return redirect()->route('mobile.index');
     }
     return redirect()->route('login');
@@ -33,7 +33,7 @@ Route::middleware(['auth','verified'])->group(function () {
          ->middleware(ShareRole::class)
          ->group(function () {
              Route::get('/', function () {
-                 $role = Auth::user()->rol;
+                 $role = Auth::user()->getRoleNames()->first();
                  return redirect()->route("mobile.{$role}.index");
              })->name('index');
 


### PR DESCRIPTION
## Summary
- use Spatie HasRoles in User model and remove obsolete `rol` attribute
- replace `Auth::user()->rol` checks with role methods and drop `rol` column
- assign roles via Spatie in user creation, factories, and seeders

## Testing
- `composer test` *(failed: require vendor/autoload.php)*
- `composer install --no-interaction --no-progress` *(failed: Failed to clone https://github.com/symfony/process.git via https, ssh protocols, aborting)*

------
https://chatgpt.com/codex/tasks/task_e_68956f621cac832595915ee8b6119c0f