### PR TITLE
Seed roles and permissions with explicit user role assignments

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,7 +2,6 @@
 
 namespace Database\Factories;
 
-use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -32,14 +31,6 @@ class UserFactory extends Factory
             'telefono' => fake()->numerify('##########'), // User's phone number,
             'remember_token' => Str::random(10),
         ];
-    }
-
-    public function configure(): static
-    {
-        return $this->afterCreating(function (User $user) {
-            $roles = ['promotor', 'administrador', 'supervisor', 'ejecutivo', 'superadmin'];
-            $user->assignRole($roles[array_rand($roles)]);
-        });
     }
 
     /**

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,9 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\User;
-use App\Models\Promotor;
-use App\Models\Supervisor;
-use App\Models\Ejecutivo;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 
@@ -16,31 +13,23 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $roles = ['promotor', 'administrador', 'supervisor', 'ejecutivo', 'superadmin'];
+        $this->call(RolePermissionSeeder::class);
 
-        foreach (range(1, 20) as $index) {
-            $user = User::factory()->create([
-                'password' => Hash::make('Password123'),
-            ]);
-            $user->assignRole($roles[array_rand($roles)]);
-        }
-
-        // Usuarios específicos
         $user = User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+            'name' => 'Super Admin',
+            'email' => 'superadmin@example.com',
             'password' => Hash::make('Password123'),
             'telefono' => '1234567890',
         ]);
         $user->assignRole('superadmin');
 
         $user = User::factory()->create([
-            'name' => 'Promotor User',
-            'email' => 'promotor@example.com',
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
             'password' => Hash::make('Password123'),
-            'telefono' => '0987654321',
+            'telefono' => '1234567890',
         ]);
-        $user->assignRole('promotor');
+        $user->assignRole('administrador');
 
         $user = User::factory()->create([
             'name' => 'Supervisor User',
@@ -57,5 +46,14 @@ class DatabaseSeeder extends Seeder
             'telefono' => '0987654321',
         ]);
         $user->assignRole('ejecutivo');
+
+        $user = User::factory()->create([
+            'name' => 'Promotor User',
+            'email' => 'promotor@example.com',
+            'password' => Hash::make('Password123'),
+            'telefono' => '0987654321',
+        ]);
+        $user->assignRole('promotor');
     }
 }
+

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class RolePermissionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $permissions = [
+            'view users',
+            'create users',
+            'edit users',
+            'delete users',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::firstOrCreate(['name' => $permission]);
+        }
+
+        $roles = [
+            'promotor' => ['view users'],
+            'administrador' => ['view users', 'create users', 'edit users', 'delete users'],
+            'supervisor' => ['view users', 'edit users'],
+            'ejecutivo' => ['view users'],
+        ];
+
+        foreach ($roles as $roleName => $rolePermissions) {
+            $role = Role::firstOrCreate(['name' => $roleName]);
+            $role->syncPermissions($rolePermissions);
+        }
+
+        $superAdminRole = Role::firstOrCreate(['name' => 'superadmin']);
+        $superAdminRole->syncPermissions(Permission::all());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add RolePermissionSeeder to define roles and permissions using Spatie\Permission
- update DatabaseSeeder to call RolePermissionSeeder and create specific users with roles
- remove automatic role assignment from UserFactory

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_6895721448508325a8beab9a84a80572