### PR TITLE
feat: add payment modal with keypad

### DIFF
--- a/resources/views/mobile/promotor/cartera/activa.blade.php
+++ b/resources/views/mobile/promotor/cartera/activa.blade.php
@@ -19,7 +19,8 @@
             <div class="flex items-center space-x-2 ml-2">
                 <button
                     class="w-8 h-8 border-2 border-green-500 text-green-500 rounded-full flex items-center justify-center"
-                    title="Registrar pago">
+                    title="Registrar pago"
+                    @click="openCalc(@js(($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))">
                     $
                 </button>
                 <a href="#"

--- a/resources/views/mobile/promotor/cartera/cartera.blade.php
+++ b/resources/views/mobile/promotor/cartera/cartera.blade.php
@@ -24,7 +24,38 @@
 @endphp
 
 <x-layouts.mobile.mobile-layout title="Tu Cartera">
-    <div class="bg-white rounded-2xl shadow p-4 w-full max-w-lg mx-auto">
+    <div x-data="{
+            showCalc: false,
+            mode: null,
+            amount: '',
+            client: '',
+            openCalc(name) {
+                this.client = name;
+                this.amount = '';
+                this.mode = null;
+                this.showCalc = true;
+            },
+            setMode(m) {
+                this.mode = m;
+                if (m === 'full') this.accept();
+            },
+            addDigit(d) {
+                this.amount += d;
+            },
+            delDigit() {
+                this.amount = this.amount.slice(0, -1);
+            },
+            accept() {
+                if (this.mode === 'deferred') {
+                    console.log('Anticipo de', this.amount, 'para', this.client);
+                } else {
+                    console.log('Pago completo para', this.client);
+                }
+                this.showCalc = false;
+                this.mode = null;
+                this.amount = '';
+            }
+        }" class="bg-white rounded-2xl shadow p-4 w-full max-w-lg mx-auto">
         <h2 class="text-center text-2xl font-bold text-gray-800 mb-6">Tu Cartera</h2>
 
         <div class="space-y-6">
@@ -49,6 +80,33 @@
                class="block w-full text-center text-blue-800 hover:text-blue-900 font-medium py-3">
                 Regresar
             </a>
+        </div>
+
+        <div x-show="showCalc" x-cloak class="fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50">
+            <div class="bg-white rounded-2xl p-6 w-72" @click.away="showCalc = false; mode = null; amount = ''">
+                <h3 class="text-lg font-bold mb-4" x-text="client"></h3>
+
+                <template x-if="mode === null">
+                    <div class="space-y-3">
+                        <button @click="setMode('full')" class="w-full py-2 bg-green-600 text-white rounded">Completo</button>
+                        <button @click="setMode('deferred')" class="w-full py-2 bg-yellow-500 text-white rounded">Diferido</button>
+                    </div>
+                </template>
+
+                <template x-if="mode === 'deferred'">
+                    <div class="space-y-4">
+                        <div class="text-right text-2xl font-semibold" x-text="amount"></div>
+                        <div class="grid grid-cols-3 gap-2">
+                            <template x-for="n in [1,2,3,4,5,6,7,8,9]" :key="n">
+                                <button @click="addDigit(n)" x-text="n" class="py-2 bg-gray-100 rounded"></button>
+                            </template>
+                            <button @click="delDigit()" class="py-2 bg-gray-100 rounded">Borrar</button>
+                            <button @click="addDigit(0)" class="py-2 bg-gray-100 rounded">0</button>
+                            <button @click="accept()" class="py-2 bg-blue-600 text-white rounded">Aceptar</button>
+                        </div>
+                    </div>
+                </template>
+            </div>
         </div>
     </div>
 </x-layouts.mobile.mobile-layout>

--- a/resources/views/mobile/promotor/cartera/vencida.blade.php
+++ b/resources/views/mobile/promotor/cartera/vencida.blade.php
@@ -16,7 +16,8 @@
             <div class="flex items-center space-x-2 ml-2">
                 <button
                     class="w-8 h-8 border-2 border-green-500 text-green-500 rounded-full flex items-center justify-center"
-                    title="Registrar pago">
+                    title="Registrar pago"
+                    @click="openCalc(@js(($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))">
                     $
                 </button>
                 <a href="#"


### PR DESCRIPTION
## Summary
- add Alpine stateful component for payments and keypad
- hook wallet payment buttons to open client-specific modal
- implement full and deferred payment options with custom numeric keypad

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e332b1b548325b672f9e3e5dc47ab