### PR TITLE
Enable multi-client payment selection in cartera views

### DIFF
--- a/resources/views/mobile/promotor/cartera/activa.blade.php
+++ b/resources/views/mobile/promotor/cartera/activa.blade.php
@@ -1,13 +1,25 @@
 <ul class="divide-y divide-gray-200">
     @forelse($activos as $c)
-        <li class="flex items-center justify-between py-2">
-            <div class="flex-1">
-                <p class="text-lg font-semibold text-gray-800">
-                    {{ $c['apellido'] ?? $c->apellido ?? '' }} {{ $c['nombre'] ?? $c->nombre ?? '' }}
-                </p>
-                <p class="text-base text-gray-600">
-                    Sem {{ $c['semana_credito'] ?? $c->semana_credito ?? '' }}
-                </p>
+        <li
+            x-data="{ cliente: @js($c) }"
+            :class="{ 'bg-blue-50': $store.multiPay.clients.some(cl => cl.id === cliente.id) }"
+            class="flex items-center justify-between py-2"
+        >
+            <div class="flex items-center flex-1">
+                <input
+                    type="checkbox"
+                    class="mr-2"
+                    @click.stop="$store.multiPay.toggle(cliente)"
+                    :checked="$store.multiPay.clients.some(cl => cl.id === cliente.id)"
+                >
+                <div>
+                    <p class="text-lg font-semibold text-gray-800">
+                        {{ $c['apellido'] ?? $c->apellido ?? '' }} {{ $c['nombre'] ?? $c->nombre ?? '' }}
+                    </p>
+                    <p class="text-base text-gray-600">
+                        Sem {{ $c['semana_credito'] ?? $c->semana_credito ?? '' }}
+                    </p>
+                </div>
             </div>
 
             <div class="w-24 text-right">
@@ -20,12 +32,14 @@
                 <button
                     class="w-8 h-8 border-2 border-green-500 text-green-500 rounded-full flex items-center justify-center"
                     title="Registrar pago"
-                 @click="$store.calc.open(@js(($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))">
+                    @click="$store.calc.open(@js(($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))"
+                >
                     $
                 </button>
                 <a href="{{route("mobile.$role.cliente_historial")}}"
                    class="w-8 h-8 border-2 border-yellow-500 text-yellow-500 rounded-full flex items-center justify-center"
-                   title="Historial">
+                   title="Historial"
+                >
                     H
                 </a>
             </div>
@@ -34,3 +48,4 @@
         <li class="py-2 text-center text-lg text-gray-500">Sin clientes activos</li>
     @endforelse
 </ul>
+

--- a/resources/views/mobile/promotor/cartera/vencida.blade.php
+++ b/resources/views/mobile/promotor/cartera/vencida.blade.php
@@ -1,10 +1,22 @@
 <ul class="divide-y divide-gray-200">
     @forelse($vencidos as $c)
-        <li class="flex items-center justify-between py-2">
-            <div class="flex-1">
-                <p class="text-base font-semibold text-gray-800">
-                    {{ ($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '') }}
-                </p>
+        <li
+            x-data="{ cliente: @js($c) }"
+            :class="{ 'bg-blue-50': $store.multiPay.clients.some(cl => cl.id === cliente.id) }"
+            class="flex items-center justify-between py-2"
+        >
+            <div class="flex items-center flex-1">
+                <input
+                    type="checkbox"
+                    class="mr-2"
+                    @click.stop="$store.multiPay.toggle(cliente)"
+                    :checked="$store.multiPay.clients.some(cl => cl.id === cliente.id)"
+                >
+                <div>
+                    <p class="text-base font-semibold text-gray-800">
+                        {{ ($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '') }}
+                    </p>
+                </div>
             </div>
 
             <div class="w-24 text-right">
@@ -17,7 +29,8 @@
                 <button
                     class="w-8 h-8 border-2 border-green-500 text-green-500 rounded-full flex items-center justify-center"
                     title="Registrar pago"
-                 @click="$store.calc.open(@js(($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))">
+                    @click="$store.calc.open(@js(($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))"
+                >
                     $
                 </button>
 
@@ -33,3 +46,4 @@
         <li class="py-2 text-center text-base text-gray-500">Sin clientes vencidos</li>
     @endforelse
 </ul>
+


### PR DESCRIPTION
## Summary
- add per-client checkboxes to active and overdue cartera lists
- highlight selected clients via multiPay store

## Testing
- `composer install`
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb62b5304c8325b3709da5ef744299