### PR TITLE
feat: toggle multi payment mode

### DIFF
--- a/resources/views/mobile/promotor/cartera/cartera.blade.php
+++ b/resources/views/mobile/promotor/cartera/cartera.blade.php
@@ -118,10 +118,29 @@
 
         <button
             class="w-full mt-6 py-2 bg-blue-600 text-white rounded"
-            @click="$store.multiPay.open()"
+            @click="$store.multiPay.toggleMode()"
         >
             Pagos Múltiples
         </button>
+
+        <div
+            x-show="$store.multiPay.active"
+            class="mt-2 flex gap-2"
+        >
+            <button
+                class="flex-1 py-2 bg-green-600 text-white rounded"
+                @click="$store.multiPay.confirm()"
+            >
+                Registrar Pagos
+            </button>
+
+            <button
+                class="flex-1 py-2 bg-red-600 text-white rounded"
+                @click="$store.multiPay.cancel()"
+            >
+                Cancelar
+            </button>
+        </div>
 
         <div class="mt-8">
             <a href="{{ route('mobile.' . ($role ?? 'promotor') . '.index') }}"


### PR DESCRIPTION
## Summary
- toggle multi payment mode instead of open
- add multi-payment action buttons with confirm and cancel

## Testing
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6529a880832581d7f6b4daacec7b