### PR TITLE
feat: add multi-pay selection handling

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,6 +3,7 @@ import Alpine from 'alpinejs';
 import authenticated from './authenticated';
 import './stores/calc';
 import './stores/details';
+import './stores/multiPay';
 
 window.Alpine = Alpine;
 window.authenticated = authenticated;

--- a/resources/js/stores/multiPay.js
+++ b/resources/js/stores/multiPay.js
@@ -1,0 +1,36 @@
+document.addEventListener('alpine:init', () => {
+    Alpine.store('multiPay', {
+        active: false,
+        show: false,
+        clients: [],
+        total: 0,
+        toggleMode() {
+            this.active = !this.active;
+            if (!this.active) {
+                this.clients = [];
+                this.total = 0;
+            }
+        },
+        toggle(cliente) {
+            const id = cliente.id ?? cliente;
+            if (this.clients.includes(id)) {
+                this.clients = this.clients.filter(c => c !== id);
+            } else {
+                this.clients.push(id);
+            }
+        },
+        confirm() {
+            this.show = true;
+        },
+        cancel() {
+            this.active = false;
+            this.clients = [];
+            this.total = 0;
+        },
+        close() {
+            this.show = false;
+            this.clients = [];
+            this.total = 0;
+        }
+    });
+});

--- a/resources/views/mobile/promotor/cartera/activa.blade.php
+++ b/resources/views/mobile/promotor/cartera/activa.blade.php
@@ -2,15 +2,17 @@
     @forelse($activos as $c)
         <li
             x-data="{ cliente: @js($c) }"
-            :class="{ 'bg-blue-50': $store.multiPay.clients.some(cl => cl.id === cliente.id) }"
+            :class="{ 'bg-blue-200': $store.multiPay.clients.includes(cliente.id) }"
             class="flex items-center justify-between py-2"
         >
             <div class="flex items-center flex-1">
                 <input
+                    x-show="$store.multiPay.active"
+                    x-cloak
                     type="checkbox"
                     class="mr-2"
                     @click.stop="$store.multiPay.toggle(cliente)"
-                    :checked="$store.multiPay.clients.some(cl => cl.id === cliente.id)"
+                    :checked="$store.multiPay.clients.includes(cliente.id)"
                 >
                 <div>
                     <p class="text-lg font-semibold text-gray-800">

--- a/resources/views/mobile/promotor/cartera/vencida.blade.php
+++ b/resources/views/mobile/promotor/cartera/vencida.blade.php
@@ -2,15 +2,17 @@
     @forelse($vencidos as $c)
         <li
             x-data="{ cliente: @js($c) }"
-            :class="{ 'bg-blue-50': $store.multiPay.clients.some(cl => cl.id === cliente.id) }"
+            :class="{ 'bg-blue-200': $store.multiPay.clients.includes(cliente.id) }"
             class="flex items-center justify-between py-2"
         >
             <div class="flex items-center flex-1">
                 <input
+                    x-show="$store.multiPay.active"
+                    x-cloak
                     type="checkbox"
                     class="mr-2"
                     @click.stop="$store.multiPay.toggle(cliente)"
-                    :checked="$store.multiPay.clients.some(cl => cl.id === cliente.id)"
+                    :checked="$store.multiPay.clients.includes(cliente.id)"
                 >
                 <div>
                     <p class="text-base font-semibold text-gray-800">


### PR DESCRIPTION
## Summary
- show client selection checkboxes only in multi-pay mode
- highlight selected clients and block checkbox click propagation
- add Alpine store to manage multi-pay state

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb67ba9e3483259327942412abefe7