### PR TITLE
Enable list item toggling for multi-pay selection

### DIFF
--- a/resources/views/mobile/promotor/cartera/activa.blade.php
+++ b/resources/views/mobile/promotor/cartera/activa.blade.php
@@ -2,7 +2,8 @@
     @forelse($activos as $c)
         <li
             x-data="{ cliente: @js($c) }"
-            :class="{ 'bg-blue-200': $store.multiPay.clients.includes(cliente.id) }"
+            :class="{ 'bg-blue-200': $store.multiPay.clients.some(c => c.id === cliente.id) }"
+            @click="$store.multiPay.active && $store.multiPay.toggle(cliente)"
             class="flex items-center justify-between py-2"
         >
             <div class="flex items-center flex-1">
@@ -12,7 +13,7 @@
                     type="checkbox"
                     class="mr-2"
                     @click.stop="$store.multiPay.toggle(cliente)"
-                    :checked="$store.multiPay.clients.includes(cliente.id)"
+                    :checked="$store.multiPay.clients.some(c => c.id === cliente.id)"
                 >
                 <div>
                     <p class="text-lg font-semibold text-gray-800">
@@ -30,7 +31,7 @@
                 </span>
             </div>
 
-            <div class="flex items-center space-x-2 ml-2">
+            <div class="flex items-center space-x-2 ml-2" x-show="!$store.multiPay.active">
                 <button
                     class="w-8 h-8 border-2 border-green-500 text-green-500 rounded-full flex items-center justify-center"
                     title="Registrar pago"

--- a/resources/views/mobile/promotor/cartera/cartera.blade.php
+++ b/resources/views/mobile/promotor/cartera/cartera.blade.php
@@ -253,35 +253,5 @@
             </div>
         </div>
 
-        {{-- Modal: Pagos Múltiples --}}
-        <div
-            x-show="$store.multiPay.show"
-            x-cloak
-            @keydown.escape.window="$store.multiPay.close()"
-            class="fixed inset-0 z-10 flex items-center justify-center bg-black/50"
-        >
-            <div class="bg-white rounded-2xl p-6 w-80" @click.away="$store.multiPay.close()" x-transition>
-                <h3 class="text-lg font-bold mb-4">Pagos Múltiples</h3>
-
-                <div class="mb-4 max-h-40 overflow-y-auto">
-                    <template x-for="client in $store.multiPay.clients" :key="client.id">
-                        <p class="py-1 border-b" x-text="client.name"></p>
-                    </template>
-                    <template x-if="$store.multiPay.clients.length === 0">
-                        <p class="text-sm text-gray-500">No hay clientes seleccionados.</p>
-                    </template>
-                </div>
-
-                <p class="font-semibold mb-4">
-                    Total a pagar:
-                    <span x-text="new Intl.NumberFormat('es-MX',{style:'currency',currency:'MXN'}).format($store.multiPay.total)"></span>
-                </p>
-
-                <div class="flex space-x-2">
-                    <button class="flex-1 py-2 bg-gray-300 rounded" @click="$store.multiPay.close()">Cancelar</button>
-                    <button class="flex-1 py-2 bg-blue-600 text-white rounded" @click="$store.multiPay.confirm()">Confirmar pagos</button>
-                </div>
-            </div>
-        </div>
     </div>
 </x-layouts.mobile.mobile-layout>

--- a/resources/views/mobile/promotor/cartera/vencida.blade.php
+++ b/resources/views/mobile/promotor/cartera/vencida.blade.php
@@ -2,7 +2,8 @@
     @forelse($vencidos as $c)
         <li
             x-data="{ cliente: @js($c) }"
-            :class="{ 'bg-blue-200': $store.multiPay.clients.includes(cliente.id) }"
+            :class="{ 'bg-blue-200': $store.multiPay.clients.some(c => c.id === cliente.id) }"
+            @click="$store.multiPay.active && $store.multiPay.toggle(cliente)"
             class="flex items-center justify-between py-2"
         >
             <div class="flex items-center flex-1">
@@ -12,7 +13,7 @@
                     type="checkbox"
                     class="mr-2"
                     @click.stop="$store.multiPay.toggle(cliente)"
-                    :checked="$store.multiPay.clients.includes(cliente.id)"
+                    :checked="$store.multiPay.clients.some(c => c.id === cliente.id)"
                 >
                 <div>
                     <p class="text-base font-semibold text-gray-800">
@@ -27,7 +28,7 @@
                 </span>
             </div>
 
-            <div class="flex items-center space-x-2 ml-2">
+            <div class="flex items-center space-x-2 ml-2" x-show="!$store.multiPay.active">
                 <button
                     class="w-8 h-8 border-2 border-green-500 text-green-500 rounded-full flex items-center justify-center"
                     title="Registrar pago"


### PR DESCRIPTION
## Summary
- Toggle multi-pay selection by clicking entire client list item
- Highlight selected clients by checking membership with `some` and hide individual actions during multi-pay
- Drop unused multi-pay modal from cartera view

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb607d4110832597d7de11bb5b9a9d