### PR TITLE
Add UUIDs to fake cartera clients

### DIFF
--- a/resources/views/mobile/promotor/cartera/cartera.blade.php
+++ b/resources/views/mobile/promotor/cartera/cartera.blade.php
@@ -4,6 +4,7 @@
     $faker = Faker::create('es_MX');
 
     $activos = collect(range(1, 5))->map(fn($i) => [
+        'id' => $faker->uuid(),
         'nombre' => $faker->firstName(),
         'apellido' => $faker->lastName(),
         'semana_credito' => $faker->numberBetween(1, 12),
@@ -14,6 +15,7 @@
         $monto = $faker->randomFloat(2, 100, 1000);
 
         return [
+            'id' => $faker->uuid(),
             'nombre' => $faker->firstName(),
             'apellido' => $faker->lastName(),
             'direccion' => $faker->address(),
@@ -30,6 +32,7 @@
     });
 
     $inactivos = collect(range(1, 2))->map(fn($i) => [
+        'id' => $faker->uuid(),
         'nombre' => $faker->firstName(),
         'apellido' => $faker->lastName(),
         'direccion' => $faker->address(),

--- a/resources/views/mobile_legacy/promotor/cartera/cartera.blade.php
+++ b/resources/views/mobile_legacy/promotor/cartera/cartera.blade.php
@@ -4,6 +4,7 @@
     $faker = Faker::create('es_MX');
 
     $activos = collect(range(1, 5))->map(fn($i) => [
+        'id' => $faker->uuid(),
         'nombre' => $faker->firstName(),
         'apellido' => $faker->lastName(),
         'semana_credito' => $faker->numberBetween(1, 12),
@@ -14,6 +15,7 @@
         $monto = $faker->randomFloat(2, 100, 1000);
 
         return [
+            'id' => $faker->uuid(),
             'nombre' => $faker->firstName(),
             'apellido' => $faker->lastName(),
             'direccion' => $faker->address(),
@@ -30,6 +32,7 @@
     });
 
     $inactivos = collect(range(1, 2))->map(fn($i) => [
+        'id' => $faker->uuid(),
         'nombre' => $faker->firstName(),
         'apellido' => $faker->lastName(),
         'direccion' => $faker->address(),


### PR DESCRIPTION
## Summary
- assign fake UUIDs to cartera clients so checkboxes can toggle correctly

## Testing
- `composer test` *(fails: Vite manifest not found)*
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_e_68bdfe2e9ac88325858989d3ad2b58da