### PR TITLE
Actualizar migración y modelo de usuarios

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,8 @@ class User extends Authenticatable
         'email',
         'password',
         'telefono', // User's phone number
+        'rol',
+        'remember_token',
     ];
 
     /**
@@ -45,6 +47,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'remember_token' => 'boolean',
         ];
     }
 

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -14,12 +14,13 @@ return new class extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->string('email')->unique();
-            $table->string('telefono', 10);
+            $table->string('email', 50)->unique();
+            $table->string('telefono', 20);
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->rememberToken();
-            $table->timestamps();
+            $table->string('rol', 20);
+            $table->boolean('remember_token')->default(false);
+            $table->timestamp('creado_en')->useCurrent();
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {


### PR DESCRIPTION
## Summary
- Ajustar longitudes de email y teléfono, agregar rol y remember_token booleano
- Reemplazar `timestamps` por `creado_en` en la migración de usuarios
- Añadir `rol` y `remember_token` (boolean) en el modelo `User`

## Testing
- `php artisan test` *(fails: Missing application key, users table missing `updated_at`)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb5cc30c8832590d73a19cb01c9a7