### PR TITLE
Actualiza columnas de ejercicios para nuevas metas de ventas

### DIFF
--- a/app/Models/Ejercicio.php
+++ b/app/Models/Ejercicio.php
@@ -7,7 +7,22 @@ use Illuminate\Database\Eloquent\Model;
 class Ejercicio extends Model
 {
     use HasFactory;
-    protected $guarded = [];
+
+    protected $fillable = [
+        'supervisor_id',
+        'ejecutivo_id',
+        'fecha_inicio',
+        'fecha_final',
+        'venta_objetivo',
+        'dinero_autorizado',
+    ];
+
+    protected $casts = [
+        'fecha_inicio' => 'date',
+        'fecha_final' => 'date',
+        'venta_objetivo' => 'decimal:2',
+        'dinero_autorizado' => 'decimal:2',
+    ];
 
     public function supervisor()
     {

--- a/database/migrations/2025_08_03_022015_create_ejercicios_table.php
+++ b/database/migrations/2025_08_03_022015_create_ejercicios_table.php
@@ -15,7 +15,8 @@ class CreateEjerciciosTable extends Migration
             $table->unsignedBigInteger('ejecutivo_id');
             $table->date('fecha_inicio');
             $table->date('fecha_final');
-            $table->decimal('dinero', 12, 2);
+            $table->decimal('venta_objetivo', 12, 2);
+            $table->decimal('dinero_autorizado', 12, 2);
 
             $table->foreign('supervisor_id')
                   ->references('id')->on('supervisores')


### PR DESCRIPTION
## Summary
- Se sustituyó la columna `dinero` por `venta_objetivo` y `dinero_autorizado` en la migración de ejercicios
- El modelo `Ejercicio` ahora expone y castea los nuevos atributos

## Testing
- `php artisan test` *(falla: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb5e6c56083258712e3ef721c1056