### PR TITLE
Rename venta_maximas column in promotores migration

### DIFF
--- a/database/migrations/2025_08_03_021957_create_promotores_table.php
+++ b/database/migrations/2025_08_03_021957_create_promotores_table.php
@@ -16,7 +16,7 @@ class CreatePromotoresTable extends Migration
             $table->string('nombre', 100);
             $table->string('apellido_p', 100);
             $table->string('apellido_m', 100);
-            $table->decimal('venta_maximas', 12, 2);
+            $table->decimal('venta_maxima', 12, 2);
             $table->string('colonia', 100);
             $table->decimal('venta_proyectada_objetivo', 12, 2);
             $table->decimal('bono', 12, 2);


### PR DESCRIPTION
## Summary
- fix promotores migration to use `venta_maxima`
- confirm `supervisor_id` stays as unsigned big integer referencing supervisores

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb5e882fc8325b48b7d36571b73c1