### PR TITLE
Renombrar campo de residencia y permitir nulos en datos de contacto

### DIFF
--- a/database/migrations/2025_08_03_022056_create_datos_contacto_table.php
+++ b/database/migrations/2025_08_03_022056_create_datos_contacto_table.php
@@ -14,14 +14,14 @@ class CreateDatosContactoTable extends Migration
             $table->unsignedBigInteger('credito_id');
             $table->string('calle', 150);
             $table->string('numero_ext', 10);
-            $table->string('numero_int', 10);
+            $table->string('numero_int', 10)->nullable();
             $table->integer('monto_mensual');
             $table->string('colonia', 100);
             $table->string('municipio', 100);
-            $table->string('estado', 100);
+            $table->string('estado', 100)->nullable();
             $table->string('cp', 10);
-            $table->string('tiempo_residencia', 20);
-            $table->string('tel_fijo', 20);
+            $table->string('tiempo_en_residencia', 20);
+            $table->string('tel_fijo', 20)->nullable();
             $table->string('tel_cel', 20);
             $table->string('tipo_de_vivienda', 100);
             $table->timestamp('creado_en')->useCurrent();


### PR DESCRIPTION
## Summary
- Renamed `tiempo_residencia` to `tiempo_en_residencia`
- Made `numero_int`, `estado`, and `tel_fijo` nullable in `datos_contacto` migration

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb5ef6f4c8325bdffbea64fad6634