### PR TITLE
Allow null values for garantía details

### DIFF
--- a/database/migrations/2025_08_03_022109_create_garantias_table.php
+++ b/database/migrations/2025_08_03_022109_create_garantias_table.php
@@ -14,9 +14,9 @@ class CreateGarantiasTable extends Migration
             $table->unsignedBigInteger('credito_id');
             $table->string('propietario', 100);
             $table->string('tipo', 100);
-            $table->string('marca', 100);
-            $table->string('modelo', 100);
-            $table->string('num_serie', 100);
+            $table->string('marca', 100)->nullable();
+            $table->string('modelo', 100)->nullable();
+            $table->string('num_serie', 100)->nullable();
             $table->string('antiguedad', 20);
             $table->decimal('monto_garantizado', 12, 2);
             $table->string('foto_url', 255);


### PR DESCRIPTION
## Summary
- make marca, modelo and num_serie nullable in garantías migration

## Testing
- `composer test` (fails: MissingAppKeyException)


------
https://chatgpt.com/codex/tasks/task_e_68bfb5f0413c8325b36ea0f928440055