### PR TITLE
Refactor comisiones for polymorphic relations

### DIFF
--- a/app/Http/Controllers/ComisionController.php
+++ b/app/Http/Controllers/ComisionController.php
@@ -20,12 +20,12 @@ class ComisionController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'tipo_beneficiado' => 'required|string',
-            'beneficiado_id'   => 'required|integer',
-            'porcentaje'       => 'required|numeric',
-            'monto_base'       => 'required|numeric',
-            'monto_pago'       => 'required|numeric',
-            'fecha_pago'       => 'required|date',
+            'comisionable_type' => 'required|string',
+            'comisionable_id'   => 'required|integer',
+            'porcentaje'        => 'required|numeric',
+            'monto_base'        => 'required|numeric',
+            'monto_pago'        => 'required|numeric',
+            'fecha_pago'        => 'required|date',
         ]);
 
         Comision::create($data);

--- a/app/Models/Comision.php
+++ b/app/Models/Comision.php
@@ -3,14 +3,15 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class Comision extends Model
 {
     use HasFactory;
     protected $guarded = [];
 
-    public function comisionable()
+    public function comisionable(): MorphTo
     {
-        return $this->morphTo();
+        return $this->morphTo(__FUNCTION__, 'comisionable_type', 'comisionable_id');
     }
 }

--- a/app/Models/Ejecutivo.php
+++ b/app/Models/Ejecutivo.php
@@ -23,4 +23,9 @@ class Ejecutivo extends Model
     {
         return $this->hasMany(Ejercicio::class);
     }
+
+    public function comisiones()
+    {
+        return $this->morphMany(Comision::class, 'comisionable');
+    }
 }

--- a/app/Models/Supervisor.php
+++ b/app/Models/Supervisor.php
@@ -28,4 +28,9 @@ class Supervisor extends Model
     {
         return $this->hasMany(Ejercicio::class);
     }
+
+    public function comisiones()
+    {
+        return $this->morphMany(Comision::class, 'comisionable');
+    }
 }

--- a/database/migrations/2025_08_03_022114_create_comisiones_table.php
+++ b/database/migrations/2025_08_03_022114_create_comisiones_table.php
@@ -11,8 +11,7 @@ class CreateComisionesTable extends Migration
     {
         Schema::create('comisiones', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('tipo_beneficiado', 20);
-            $table->unsignedBigInteger('beneficiado_id');
+            $table->morphs('comisionable');
             $table->decimal('porcentaje', 5, 2);
             $table->decimal('monto_base', 12, 2);
             $table->decimal('monto_pago', 12, 2);


### PR DESCRIPTION
## Summary
- use polymorphic comisionable keys in comisiones migration
- switch Comision model to morph relation and expose comisiones on beneficiary models
- update ComisionController to validate new polymorphic fields

## Testing
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb5f1dd708325beea26d5e9c8c771