### PR TITLE
Allow searching across Excel sheets when no sheet is selected

### DIFF
--- a/app/Http/Controllers/ExcelController.php
+++ b/app/Http/Controllers/ExcelController.php
@@ -10,26 +10,33 @@ class ExcelController extends Controller
     public function index(Request $request, ExcelReaderService $excel)
     {
         // Parámetros de búsqueda
-        $sheet   = $request->input('sheet');
-        $filters = $request->only(['q','date_from','date_to','monto_min','monto_max']);
-        $limit   = (int) $request->input('limit', 50);
-        $offset  = (int) $request->input('offset', 0);
+        $sheet = $request->input('sheet');
+        $filters = $request->only(['q', 'date_from', 'date_to', 'monto_min', 'monto_max']);
+        $limit = (int) $request->input('limit', 50);
+        $offset = (int) $request->input('offset', 0);
+        $context = (int) $request->input('context', 3);
+        $searchAll = $request->boolean('search_all');
 
         // Listar hojas
         $sheets = $excel->listSheets();
 
         $data = null;
-        if ($sheet) {
+        $results = null;
+        if (! $sheet || $searchAll) {
+            $results = $excel->searchAllSheets($filters['q'] ?? '', $context);
+        } else {
             $data = $excel->getSheetRows($sheet, $filters, $limit, $offset);
         }
 
         return view('consulta_base_datos_historica', [
-            'sheets'  => $sheets,
+            'sheets' => $sheets,
             'current' => $sheet,
-            'data'    => $data,
+            'data' => $data,
+            'results' => $results,
             'filters' => $filters,
-            'limit'   => $limit,
-            'offset'  => $offset,
+            'limit' => $limit,
+            'offset' => $offset,
+            'context' => $context,
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- Support global Excel search when no sheet is specified or `search_all` is present
- Allow configurable context via `context` query parameter and forward results to the view

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c06b521b8c8325bbad1833f338895d