### PR TITLE
Adjust ExcelController to search all sheets when querying

### DIFF
--- a/app/Http/Controllers/ExcelController.php
+++ b/app/Http/Controllers/ExcelController.php
@@ -15,17 +15,22 @@ class ExcelController extends Controller
         $limit = (int) $request->input('limit', 50);
         $offset = (int) $request->input('offset', 0);
         $context = (int) $request->input('context', 3);
-        $searchAll = $request->boolean('search_all');
 
-        // Listar hojas
-        $sheets = $excel->listSheets();
+        // Listar hojas solo si se solicita explícitamente
+        $sheets = [];
+        if ($request->boolean('list_sheets')) {
+            $sheets = $excel->listSheets();
+        }
 
         $data = null;
-        $results = null;
-        if (! $sheet || $searchAll) {
-            $results = $excel->searchAllSheets($filters['q'] ?? '', $context);
-        } else {
+        if ($sheet) {
             $data = $excel->getSheetRows($sheet, $filters, $limit, $offset);
+        }
+
+        $results = null;
+        $q = $filters['q'] ?? null;
+        if ($q !== null && $q !== '') {
+            $results = $excel->searchAllSheets($q, $context);
         }
 
         return view('consulta_base_datos_historica', [


### PR DESCRIPTION
## Summary
- Only list Excel sheets when explicitly requested
- Always search across all sheets when `q` query is present and allow configurable context

## Testing
- `composer test` *(fails: MissingAppKeyException, table users has no column named updated_at)*

------
https://chatgpt.com/codex/tasks/task_e_68c073102ca883259c829ace93f48545