### PR TITLE
Handle search results without row metadata

### DIFF
--- a/resources/views/consulta_base_datos_historica.blade.php
+++ b/resources/views/consulta_base_datos_historica.blade.php
@@ -24,7 +24,9 @@
         @if($results !== null)
             @php
                 $contextHeaders = collect($results)
-                    ->flatMap(fn($r) => array_keys($r['context'] ?? []))
+                    ->flatMap(function ($r) {
+                        return array_keys($r['context'] ?? []);
+                    })
                     ->unique()
                     ->take($context)
                     ->all();
@@ -36,12 +38,10 @@
                         <thead class="bg-gray-100">
                             <tr>
                                 <th class="px-3 py-2 text-left font-semibold">Hoja</th>
-                                <th class="px-3 py-2 text-left font-semibold">Fila</th>
-                                <th class="px-3 py-2 text-left font-semibold">Columna coincidencia</th>
                                 <th class="px-3 py-2 text-left font-semibold">Valor</th>
                                 @foreach($contextHeaders as $header)
                                     <th class="px-3 py-2 text-left font-semibold">
-                                        {{ ucfirst(str_replace('_',' ', $header)) }}
+                                        {{ $header }}
                                     </th>
                                 @endforeach
                             </tr>
@@ -50,8 +50,6 @@
                             @foreach($results as $row)
                                 <tr>
                                     <td class="px-3 py-2">{{ $row['sheet'] }}</td>
-                                    <td class="px-3 py-2">{{ $row['row'] }}</td>
-                                    <td class="px-3 py-2">{{ $row['match_column'] }}</td>
                                     <td class="px-3 py-2">{{ $row['match_value'] }}</td>
                                     @foreach($contextHeaders as $header)
                                         <td class="px-3 py-2">{{ $row['context'][$header] ?? '' }}</td>


### PR DESCRIPTION
## Summary
- Process Excel search results without relying on removed row or match_column fields
- Build context headers from original column names and simplify multi-sheet results table

## Testing
- `composer test` *(fails: table users has no column named updated_at)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b8644aa08325b5dbda0e86647648