### PR TITLE
Refine historical multi-sheet results view

### DIFF
--- a/resources/views/consulta_base_datos_historica.blade.php
+++ b/resources/views/consulta_base_datos_historica.blade.php
@@ -24,9 +24,7 @@
         @if($results !== null)
             @php
                 $contextHeaders = collect($results)
-                    ->flatMap(function ($r) {
-                        return array_keys($r['context'] ?? []);
-                    })
+                    ->flatMap(fn ($r) => array_keys($r['context'] ?? []))
                     ->unique()
                     ->take($context)
                     ->all();
@@ -39,6 +37,7 @@
                             <tr>
                                 <th class="px-3 py-2 text-left font-semibold">Hoja</th>
                                 <th class="px-3 py-2 text-left font-semibold">Valor</th>
+                                {{-- Cabeceras contextuales generadas dinámicamente --}}
                                 @foreach($contextHeaders as $header)
                                     <th class="px-3 py-2 text-left font-semibold">
                                         {{ $header }}


### PR DESCRIPTION
## Summary
- streamline context header collection with arrow function
- document and render dynamic context headers alongside sheet and value

## Testing
- `php artisan test` *(fails: table users has no column named updated_at)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bcff54448325a9207f0c4dba9264