### PR TITLE
Handle DateTime headers in Excel search

### DIFF
--- a/app/Services/ExcelReaderService.php
+++ b/app/Services/ExcelReaderService.php
@@ -122,7 +122,7 @@ class ExcelReaderService
                 $cells = $row->toArray();
 
                 if ($rowIndex === 1) {
-                    $headersRaw = array_map(fn ($h) => trim((string) $h), $cells);
+                    $headersRaw = array_map(fn ($h) => $this->normalizeCellValue($h) ?? '', $cells);
                     $headers = array_map(function ($h) {
                         $formatted = $this->normalizeCellValue($h) ?? '';
                         return Str::of($formatted)->trim()->lower()->snake()->toString();


### PR DESCRIPTION
## Summary
- Normalize header cells when scanning sheets to avoid DateTime cast errors

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000]: General error: 1 table users has no column named updated_at)*

------
https://chatgpt.com/codex/tasks/task_e_68c06428badc83258b09f5317d7f6f6b