### PR TITLE
feat: add user seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -54,6 +54,8 @@ class DatabaseSeeder extends Seeder
             'telefono' => '0987654321',
         ]);
         $user->assignRole('promotor');
+
+        $this->call(UserSeeder::class);
     }
 }
 

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        User::factory()->count(20)->create();
+    }
+}


### PR DESCRIPTION
## Summary
- add seeder that generates 20 random users
- register UserSeeder in DatabaseSeeder

## Testing
- `php artisan test` *(fails: No application encryption key has been specified / database missing columns)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e04b55388325bbca4ff830073aca