### PR TITLE
feat: agregar seeder de ejecutivos

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call(RolePermissionSeeder::class);
+        $this->call([
+            RolePermissionSeeder::class,
+            EjecutivoSeeder::class,
+        ]);
 
         $user = User::factory()->create([
             'name' => 'Super Admin',

--- a/database/seeders/EjecutivoSeeder.php
+++ b/database/seeders/EjecutivoSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Ejecutivo;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class EjecutivoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $user = User::factory()->create();
+
+            Ejecutivo::create([
+                'user_id' => $user->id,
+                'nombre' => fake()->firstName(),
+                'apellido_p' => fake()->lastName(),
+                'apellido_m' => fake()->lastName(),
+            ]);
+
+            $user->assignRole('ejecutivo');
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- agregar seeder para generar 20 ejecutivos con usuarios asociados
- registrar `EjecutivoSeeder` en el `DatabaseSeeder`

## Testing
- `./vendor/bin/pest` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e04cd274832588a07c31df171a77