### PR TITLE
Add SupervisorSeeder and register in DatabaseSeeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -54,6 +54,8 @@ class DatabaseSeeder extends Seeder
             'telefono' => '0987654321',
         ]);
         $user->assignRole('promotor');
+
+        $this->call(SupervisorSeeder::class);
     }
 }
 

--- a/database/seeders/SupervisorSeeder.php
+++ b/database/seeders/SupervisorSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Supervisor;
+
+class SupervisorSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            Supervisor::create([
+                'user_id' => ($i % 5) + 1,
+                'ejecutivo_id' => 1,
+                'nombre' => 'Supervisor ' . $i,
+                'apellido_p' => 'ApellidoP' . $i,
+                'apellido_m' => 'ApellidoM' . $i,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SupervisorSeeder with 20 sample Supervisor records
- register SupervisorSeeder in DatabaseSeeder

## Testing
- `php artisan test` *(fails: table users has no column named updated_at)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e04db9ac8325a6080806591e883f