### PR TITLE
Add Ejercicio seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -54,6 +54,8 @@ class DatabaseSeeder extends Seeder
             'telefono' => '0987654321',
         ]);
         $user->assignRole('promotor');
+
+        $this->call(EjercicioSeeder::class);
     }
 }
 

--- a/database/seeders/EjercicioSeeder.php
+++ b/database/seeders/EjercicioSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Ejercicio;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+
+class EjercicioSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            $inicio = Carbon::now()->subMonths($i);
+            $final = (clone $inicio)->addMonths(3);
+
+            Ejercicio::create([
+                'supervisor_id' => 1,
+                'ejecutivo_id' => 1,
+                'fecha_inicio' => $inicio,
+                'fecha_final' => $final,
+                'venta_objetivo' => 10000 * $i,
+                'dinero_autorizado' => 8000 * $i,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- seed 20 sample `Ejercicio` records for testing
- register `EjercicioSeeder` in `DatabaseSeeder`

## Testing
- `php artisan test` *(fails: MissingAppKeyException, database errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e050ee348325809af821bdc20124