### PR TITLE
Add ClienteSeeder and register in DatabaseSeeder

### DIFF
--- a/database/seeders/ClienteSeeder.php
+++ b/database/seeders/ClienteSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Cliente;
+use Illuminate\Database\Seeder;
+
+class ClienteSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            Cliente::create([
+                'promotor_id' => 1,
+                'CURP' => 'CURP' . str_pad($i, 14, '0', STR_PAD_LEFT),
+                'nombre' => 'Cliente ' . $i,
+                'apellido_p' => 'ApellidoP ' . $i,
+                'apellido_m' => 'ApellidoM ' . $i,
+                'fecha_nacimiento' => now()->subYears(30)->subDays($i),
+                'tiene_credito_activo' => false,
+                'estatus' => 'activo',
+                'monto_maximo' => 10000,
+                'activo' => true,
+            ]);
+        }
+    }
+}
+

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call(RolePermissionSeeder::class);
+        $this->call([
+            RolePermissionSeeder::class,
+            ClienteSeeder::class,
+        ]);
 
         $user = User::factory()->create([
             'name' => 'Super Admin',


### PR DESCRIPTION
## Summary
- seed sample clients with new `ClienteSeeder`
- run `ClienteSeeder` from `DatabaseSeeder`

## Testing
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e05282248325ad5e4754c4541849