### PR TITLE
feat: seed credits

### DIFF
--- a/database/seeders/CreditoSeeder.php
+++ b/database/seeders/CreditoSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Credito;
+use App\Models\Cliente;
+use Carbon\Carbon;
+
+class CreditoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $clientes = Cliente::all();
+
+        if ($clientes->isEmpty()) {
+            return;
+        }
+
+        foreach (range(1, 20) as $i) {
+            $cliente = $clientes->random();
+            $fechaInicio = Carbon::now()->subMonths(rand(0, 12));
+            Credito::create([
+                'cliente_id' => $cliente->id,
+                'monto_total' => rand(1000, 100000) / 100,
+                'estado' => 'activo',
+                'interes' => rand(5, 20),
+                'periodicidad' => 'mensual',
+                'fecha_inicio' => $fechaInicio->toDateString(),
+                'fecha_final' => $fechaInicio->copy()->addMonths(rand(6, 24))->toDateString(),
+            ]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -54,6 +54,8 @@ class DatabaseSeeder extends Seeder
             'telefono' => '0987654321',
         ]);
         $user->assignRole('promotor');
+
+        $this->call(CreditoSeeder::class);
     }
 }
 


### PR DESCRIPTION
## Summary
- add seeder for generating 20 credits linked to clients
- register credit seeder in database seeder

## Testing
- `php artisan test` *(fails: No application encryption key and missing column `updated_at` in `users` table)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e05339c483258ac90df9390d8869