### PR TITLE
Add PagoReal seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call(RolePermissionSeeder::class);
+        $this->call(PagoRealSeeder::class);
 
         $user = User::factory()->create([
             'name' => 'Super Admin',

--- a/database/seeders/PagoRealSeeder.php
+++ b/database/seeders/PagoRealSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\PagoReal;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+
+class PagoRealSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            PagoReal::create([
+                'pago_proyectado_id' => $i,
+                'tipo' => 'completo',
+                'fecha_pago' => Carbon::now()->subDays($i)->toDateString(),
+                'comentario' => 'Pago ' . $i,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PagoRealSeeder inserting 20 payment records
- register PagoRealSeeder in DatabaseSeeder

## Testing
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 table users has no column named updated_at)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e0563ac483258ae4c7d6019fda70