### PR TITLE
Add Ocupacion seeder and registration

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call(RolePermissionSeeder::class);
+        $this->call([
+            RolePermissionSeeder::class,
+            OcupacionSeeder::class,
+        ]);
 
         $user = User::factory()->create([
             'name' => 'Super Admin',

--- a/database/seeders/OcupacionSeeder.php
+++ b/database/seeders/OcupacionSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Ocupacion;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+
+class OcupacionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            Ocupacion::create([
+                'credito_id' => 1,
+                'actividad' => 'Ocupacion ' . $i,
+                'nombre_empresa' => 'Empresa ' . $i,
+                'calle' => 'Calle ' . $i,
+                'numero' => (string) $i,
+                'colonia' => 'Colonia ' . $i,
+                'municipio' => 'Municipio ' . $i,
+                'telefono' => '5550000' . str_pad($i, 3, '0', STR_PAD_LEFT),
+                'antiguedad' => $i . ' años',
+                'monto_percibido' => 1000 * $i,
+                'periodo_pago' => 'Mensual',
+                'creado_en' => Carbon::now(),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add OcupacionSeeder to populate 20 sample occupations
- register OcupacionSeeder in DatabaseSeeder

## Testing
- `php artisan test` *(fails: No application encryption key has been specified; table users has no column named updated_at)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e058a9348325a12d30dd94ef7e96