### PR TITLE
Add PagoCompleto seeder with 20 records

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call(RolePermissionSeeder::class);
+        $this->call(PagoCompletoSeeder::class);
 
         $user = User::factory()->create([
             'name' => 'Super Admin',

--- a/database/seeders/PagoCompletoSeeder.php
+++ b/database/seeders/PagoCompletoSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\PagoCompleto;
+
+class PagoCompletoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            PagoCompleto::create([
+                'pago_real_id' => $i,
+                'monto_completo' => 1000 * $i,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PagoCompletoSeeder to generate 20 pago completo records
- register PagoCompletoSeeder in DatabaseSeeder

## Testing
- `php -l database/seeders/PagoCompletoSeeder.php`
- `php -l database/seeders/DatabaseSeeder.php`
- `php artisan test` *(fails: MissingAppKeyException; 24 failed, 1 warning, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e05d4bac83258b1a2ef6dae5b593