### PR TITLE
Add GarantiaSeeder for sample guarantees

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,8 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(RolePermissionSeeder::class);
 
+        $this->call(GarantiaSeeder::class);
+
         $user = User::factory()->create([
             'name' => 'Super Admin',
             'email' => 'superadmin@example.com',

--- a/database/seeders/GarantiaSeeder.php
+++ b/database/seeders/GarantiaSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Garantia;
+use Illuminate\Database\Seeder;
+
+class GarantiaSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            Garantia::create([
+                'credito_id' => 1,
+                'propietario' => 'Propietario ' . $i,
+                'tipo' => 'Tipo ' . $i,
+                'marca' => 'Marca ' . $i,
+                'modelo' => 'Modelo ' . $i,
+                'num_serie' => 'NUMSERIE' . $i,
+                'antiguedad' => $i . ' años',
+                'monto_garantizado' => 1000 + ($i * 100),
+                'foto_url' => 'https://example.com/foto' . $i . '.jpg',
+            ]);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add GarantiaSeeder to generate 20 sample guarantees
- register GarantiaSeeder within DatabaseSeeder

## Testing
- `php artisan test` *(fails: MissingAppKeyException, users table missing updated_at column)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e06bf28c8325a09a182bc4b12a54