### PR TITLE
Add contrato seeder

### DIFF
--- a/database/seeders/ContratoSeeder.php
+++ b/database/seeders/ContratoSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Contrato;
+use Illuminate\Database\Seeder;
+
+class ContratoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            Contrato::create([
+                'credito_id' => $i,
+                'tipo_contrato' => 'Tipo '.$i,
+                'fecha_generacion' => now()->subDays($i),
+                'url_s3' => 'https://example.com/contratos/contrato'.$i.'.pdf',
+            ]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call(RolePermissionSeeder::class);
+        $this->call(ContratoSeeder::class);
 
         $user = User::factory()->create([
             'name' => 'Super Admin',
@@ -56,4 +57,3 @@ class DatabaseSeeder extends Seeder
         $user->assignRole('promotor');
     }
 }
-


### PR DESCRIPTION
## Summary
- add ContratoSeeder to generate 20 contrato records
- register ContratoSeeder in DatabaseSeeder

## Testing
- `php artisan test` *(fails: No application encryption key has been specified; table users has no column named updated_at)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e06d07288325b076a389d55b32a0