### PR TITLE
Add Inversion seeder and register in DatabaseSeeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call(RolePermissionSeeder::class);
+        $this->call(InversionSeeder::class);
 
         $user = User::factory()->create([
             'name' => 'Super Admin',

--- a/database/seeders/InversionSeeder.php
+++ b/database/seeders/InversionSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Inversion;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+
+class InversionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            Inversion::create([
+                'promotor_id' => 1,
+                'monto_solicitado' => 1000 * $i,
+                'monto_aprobado' => 900 * $i,
+                'fecha_solicitud' => Carbon::now()->subDays($i + 1),
+                'fecha_aprobacion' => Carbon::now()->subDays($i),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `InversionSeeder` to generate sample inversion records
- register `InversionSeeder` within `DatabaseSeeder`

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e06e0c508325a12daaa335182dd6