### PR TITLE
Add seeder for administrativos and register it

### DIFF
--- a/database/seeders/AdministrativoSeeder.php
+++ b/database/seeders/AdministrativoSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Administrativo;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class AdministrativoSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $user = User::factory()->create();
+
+            Administrativo::create([
+                'user_id' => $user->id,
+            ]);
+        }
+    }
+}
+

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call(RolePermissionSeeder::class);
+        $this->call(AdministrativoSeeder::class);
 
         $user = User::factory()->create([
             'name' => 'Super Admin',


### PR DESCRIPTION
## Summary
- add `AdministrativoSeeder` to create 20 administrative users
- register `AdministrativoSeeder` in `DatabaseSeeder`

## Testing
- `php artisan test` *(fails: table users has no column named updated_at)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e06f45148325b6e0bd02bb9664dc