### PR TITLE
Seed 20 roles and permissions

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call(RolePermissionSeeder::class);
+        $this->call([
+            RolePermissionSeeder::class,
+        ]);
 
         $user = User::factory()->create([
             'name' => 'Super Admin',

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -10,31 +10,32 @@ class RolePermissionSeeder extends Seeder
 {
     public function run(): void
     {
-        $permissions = [
-            'view users',
-            'create users',
-            'edit users',
-            'delete users',
-        ];
-
-        foreach ($permissions as $permission) {
-            Permission::firstOrCreate(['name' => $permission]);
+        $permissions = [];
+        for ($i = 1; $i <= 20; $i++) {
+            $permissions[] = Permission::create(['name' => 'permission'.$i]);
         }
 
-        $roles = [
-            'promotor' => ['view users'],
-            'administrador' => ['view users', 'create users', 'edit users', 'delete users'],
-            'supervisor' => ['view users', 'edit users'],
-            'ejecutivo' => ['view users'],
+        $roleNames = [
+            'superadmin',
+            'administrador',
+            'supervisor',
+            'ejecutivo',
+            'promotor',
         ];
-
-        foreach ($roles as $roleName => $rolePermissions) {
-            $role = Role::firstOrCreate(['name' => $roleName]);
-            $role->syncPermissions($rolePermissions);
+        for ($i = 1; $i <= 15; $i++) {
+            $roleNames[] = 'role'.$i;
         }
 
-        $superAdminRole = Role::firstOrCreate(['name' => 'superadmin']);
-        $superAdminRole->syncPermissions(Permission::all());
+        $roles = [];
+        foreach ($roleNames as $roleName) {
+            $roles[] = Role::create(['name' => $roleName]);
+        }
+
+        foreach ($roles as $role) {
+            foreach ($permissions as $permission) {
+                $role->givePermissionTo($permission);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- generate 20 permissions and roles with loops and assign all permissions to each role
- register RolePermissionSeeder within DatabaseSeeder

## Testing
- `php artisan test` (fails: No application encryption key and missing columns)


------
https://chatgpt.com/codex/tasks/task_e_68c1e07204208325b6688bf785b214bb