### PR TITLE
feat: add documento seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call(RolePermissionSeeder::class);
+        $this->call([
+            RolePermissionSeeder::class,
+            DocumentoSeeder::class,
+        ]);
 
         $user = User::factory()->create([
             'name' => 'Super Admin',

--- a/database/seeders/DocumentoSeeder.php
+++ b/database/seeders/DocumentoSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Documento;
+use Illuminate\Database\Seeder;
+
+class DocumentoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            Documento::create([
+                'credito_id' => 1,
+                'promotor_id' => 1,
+                'supervisor_id' => 1,
+                'ejecutivo_id' => 1,
+                'tipo_documento_id' => 1,
+                'fecha_generacion' => now()->subDays($i),
+                'url_s3' => "documents/documento_{$i}.pdf",
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `DocumentoSeeder` to populate 20 base documents
- register `DocumentoSeeder` in `DatabaseSeeder`

## Testing
- `php artisan test` *(fails: MissingAppKeyException, tables missing columns)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e070e86c832592bdfe5776b4f3aa