### PR TITLE
Align models and seeders with custom schema

### DIFF
--- a/app/Models/Aval.php
+++ b/app/Models/Aval.php
@@ -8,6 +8,9 @@ class Aval extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = null;
+    protected $table = 'avales';
 
     public function credito()
     {

--- a/app/Models/Cliente.php
+++ b/app/Models/Cliente.php
@@ -8,6 +8,8 @@ class Cliente extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = 'actualizado_en';
 
     public function promotor()
     {

--- a/app/Models/Comision.php
+++ b/app/Models/Comision.php
@@ -9,6 +9,8 @@ class Comision extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    public $timestamps = false;
+    protected $table = 'comisiones';
 
     public function comisionable(): MorphTo
     {

--- a/app/Models/Credito.php
+++ b/app/Models/Credito.php
@@ -18,6 +18,8 @@ class Credito extends Model
         'fecha_final',
     ];
 
+    public $timestamps = false;
+
     public function cliente()
     {
         return $this->belongsTo(Cliente::class);

--- a/app/Models/DatoContacto.php
+++ b/app/Models/DatoContacto.php
@@ -8,6 +8,9 @@ class DatoContacto extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = null;
+    protected $table = 'datos_contacto';
 
     public function credito()
     {

--- a/app/Models/Documento.php
+++ b/app/Models/Documento.php
@@ -8,6 +8,7 @@ class Documento extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    public $timestamps = false;
 
     public function credito()
     {

--- a/app/Models/DocumentoAval.php
+++ b/app/Models/DocumentoAval.php
@@ -8,6 +8,9 @@ class DocumentoAval extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = null;
+    protected $table = 'documentos_avales';
 
     public function aval()
     {

--- a/app/Models/DocumentoCliente.php
+++ b/app/Models/DocumentoCliente.php
@@ -8,6 +8,9 @@ class DocumentoCliente extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = null;
+    protected $table = 'documentos_clientes';
 
     public function cliente()
     {

--- a/app/Models/Ejecutivo.php
+++ b/app/Models/Ejecutivo.php
@@ -8,6 +8,7 @@ class Ejecutivo extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    public $timestamps = false;
 
     public function user()
     {

--- a/app/Models/Ejercicio.php
+++ b/app/Models/Ejercicio.php
@@ -24,6 +24,8 @@ class Ejercicio extends Model
         'dinero_autorizado' => 'decimal:2',
     ];
 
+    public $timestamps = false;
+
     public function supervisor()
     {
         return $this->belongsTo(Supervisor::class);

--- a/app/Models/Garantia.php
+++ b/app/Models/Garantia.php
@@ -8,6 +8,8 @@ class Garantia extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = null;
 
     public function credito()
     {

--- a/app/Models/InformacionFamiliar.php
+++ b/app/Models/InformacionFamiliar.php
@@ -8,6 +8,9 @@ class InformacionFamiliar extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = null;
+    protected $table = 'informacion_familiares';
 
     public function credito()
     {

--- a/app/Models/IngresoAdicional.php
+++ b/app/Models/IngresoAdicional.php
@@ -8,6 +8,9 @@ class IngresoAdicional extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = null;
+    protected $table = 'ingresos_adicionales';
 
     public function ocupacion()
     {

--- a/app/Models/Inversion.php
+++ b/app/Models/Inversion.php
@@ -8,6 +8,8 @@ class Inversion extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    public $timestamps = false;
+    protected $table = 'inversiones';
 
     public function promotor()
     {

--- a/app/Models/Ocupacion.php
+++ b/app/Models/Ocupacion.php
@@ -8,6 +8,9 @@ class Ocupacion extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = null;
+    protected $table = 'ocupaciones';
 
     public function credito()
     {

--- a/app/Models/PagoAnticipo.php
+++ b/app/Models/PagoAnticipo.php
@@ -10,6 +10,7 @@ class PagoAnticipo extends Model
     use HasFactory;
     protected $guarded = [];
     protected $table = 'pagos_anticipo';
+    const UPDATED_AT = null;
 
     public function pagoReal()
     {

--- a/app/Models/PagoCompleto.php
+++ b/app/Models/PagoCompleto.php
@@ -10,6 +10,7 @@ class PagoCompleto extends Model
     use HasFactory;
     protected $guarded = [];
     protected $table = 'pagos_completos';
+    const UPDATED_AT = null;
 
     public function pagoReal()
     {

--- a/app/Models/PagoDiferido.php
+++ b/app/Models/PagoDiferido.php
@@ -10,6 +10,7 @@ class PagoDiferido extends Model
     use HasFactory;
     protected $guarded = [];
     protected $table = 'pagos_diferidos';
+    const UPDATED_AT = null;
 
     public function pagoReal()
     {

--- a/app/Models/PagoProyectado.php
+++ b/app/Models/PagoProyectado.php
@@ -9,6 +9,7 @@ class PagoProyectado extends Model
     use HasFactory;
     protected $guarded = [];
     protected $table = 'pagos_proyectados';
+    public $timestamps = false;
 
     public function credito()
     {

--- a/app/Models/PagoReal.php
+++ b/app/Models/PagoReal.php
@@ -9,6 +9,7 @@ class PagoReal extends Model
     use HasFactory;
     protected $guarded = [];
     protected $table = 'pagos_reales';
+    const UPDATED_AT = null;
 
     public function pagoProyectado()
     {

--- a/app/Models/Promotor.php
+++ b/app/Models/Promotor.php
@@ -8,6 +8,9 @@ class Promotor extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = 'actualizado_en';
+    protected $table = 'promotores';
 
     public function user()
     {

--- a/app/Models/Supervisor.php
+++ b/app/Models/Supervisor.php
@@ -8,6 +8,8 @@ class Supervisor extends Model
 {
     use HasFactory;
     protected $guarded = [];
+    public $timestamps = false;
+    protected $table = 'supervisores';
 
     public function user()
     {

--- a/app/Models/TipoDocumento.php
+++ b/app/Models/TipoDocumento.php
@@ -1,17 +1,14 @@
 <?php
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Contrato extends Model
+class TipoDocumento extends Model
 {
     use HasFactory;
-    protected $guarded = [];
     public $timestamps = false;
-
-    public function credito()
-    {
-        return $this->belongsTo(Credito::class);
-    }
+    protected $guarded = [];
+    protected $table = 'tipo_documentos';
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,6 +14,12 @@ class User extends Authenticatable
     use HasFactory, Notifiable, HasRoles;
 
     /**
+     * Custom timestamp columns.
+     */
+    const CREATED_AT = 'creado_en';
+    const UPDATED_AT = null;
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var list<string>

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'telefono' => fake()->numerify('##########'), // User's phone number,
+            'rol' => 'user',
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/migrations/2025_08_08_032528_create_tipo_documentos_table.php
+++ b/database/migrations/2025_08_08_032528_create_tipo_documentos_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tipo_documentos', function (Blueprint $table) {
+            $table->id();
+            $table->string('nombre', 100);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tipo_documentos');
+    }
+};

--- a/database/seeders/AdministrativoSeeder.php
+++ b/database/seeders/AdministrativoSeeder.php
@@ -11,7 +11,7 @@ class AdministrativoSeeder extends Seeder
     public function run(): void
     {
         for ($i = 0; $i < 20; $i++) {
-            $user = User::factory()->create();
+            $user = User::factory()->create(['rol' => 'administrativo']);
             Administrativo::create([
                 'user_id' => $user->id,
             ]);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -38,6 +38,7 @@ class DatabaseSeeder extends Seeder
             InversionSeeder::class,
             ComisionSeeder::class,
             AdministrativoSeeder::class,
+            TipoDocumentoSeeder::class,
             DocumentoSeeder::class,
             UserSeeder::class,
         ]);
@@ -47,6 +48,7 @@ class DatabaseSeeder extends Seeder
             'email' => 'superadmin@example.com',
             'password' => Hash::make('12345'),
             'telefono' => '1234567890',
+            'rol' => 'superadmin',
         ]);
         $user->assignRole('superadmin');
 
@@ -55,6 +57,7 @@ class DatabaseSeeder extends Seeder
             'email' => 'admin@example.com',
             'password' => Hash::make('12345'),
             'telefono' => '1234567890',
+            'rol' => 'administrador',
         ]);
         $user->assignRole('administrador');
 
@@ -63,6 +66,7 @@ class DatabaseSeeder extends Seeder
             'email' => 'supervisor@example.com',
             'password' => Hash::make('12345'),
             'telefono' => '0987654321',
+            'rol' => 'supervisor',
         ]);
         $user->assignRole('supervisor');
 
@@ -71,6 +75,7 @@ class DatabaseSeeder extends Seeder
             'email' => 'ejecutivo@example.com',
             'password' => Hash::make('12345'),
             'telefono' => '0987654321',
+            'rol' => 'ejecutivo',
         ]);
         $user->assignRole('ejecutivo');
 
@@ -79,6 +84,7 @@ class DatabaseSeeder extends Seeder
             'email' => 'promotor@example.com',
             'password' => Hash::make('12345'),
             'telefono' => '0987654321',
+            'rol' => 'promotor',
         ]);
         $user->assignRole('promotor');
     }

--- a/database/seeders/EjecutivoSeeder.php
+++ b/database/seeders/EjecutivoSeeder.php
@@ -11,7 +11,7 @@ class EjecutivoSeeder extends Seeder
     public function run(): void
     {
         for ($i = 0; $i < 20; $i++) {
-            $user = User::factory()->create();
+            $user = User::factory()->create(['rol' => 'ejecutivo']);
 
             Ejecutivo::create([
                 'user_id' => $user->id,

--- a/database/seeders/PromotorSeeder.php
+++ b/database/seeders/PromotorSeeder.php
@@ -14,7 +14,7 @@ class PromotorSeeder extends Seeder
         $supervisores = Supervisor::all();
 
         for ($i = 0; $i < 20; $i++) {
-            $user = User::factory()->create();
+            $user = User::factory()->create(['rol' => 'promotor']);
             Promotor::create([
                 'user_id' => $user->id,
                 'supervisor_id' => $supervisores->random()->id,

--- a/database/seeders/SupervisorSeeder.php
+++ b/database/seeders/SupervisorSeeder.php
@@ -14,7 +14,7 @@ class SupervisorSeeder extends Seeder
         $ejecutivos = Ejecutivo::all();
 
         for ($i = 0; $i < 20; $i++) {
-            $user = User::factory()->create();
+            $user = User::factory()->create(['rol' => 'supervisor']);
             Supervisor::create([
                 'user_id' => $user->id,
                 'ejecutivo_id' => $ejecutivos->random()->id,

--- a/database/seeders/TipoDocumentoSeeder.php
+++ b/database/seeders/TipoDocumentoSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\TipoDocumento;
+
+class TipoDocumentoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        TipoDocumento::create(['nombre' => 'default']);
+    }
+}


### PR DESCRIPTION
## Summary
- map all models to custom timestamp columns and table names
- seed users with required `rol` field and add tipo_documentos support
- include migration, model, and seeder for document types

## Testing
- `php artisan migrate:fresh --force`
- `php artisan db:seed --force`
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e914aca48325a7e0ca56b6d31957