### PR TITLE
Check aval active credit before recredit

### DIFF
--- a/app/Http/Controllers/Mobile/PromotorController.php
+++ b/app/Http/Controllers/Mobile/PromotorController.php
@@ -253,11 +253,8 @@ class PromotorController extends Controller
                     ];
                 }
 
-                $avalActivo = Aval::where('CURP', $avalCurp)
-                    ->whereHas('credito', fn($q) => $q->where('estado', 'activo'))
-                    ->latest('creado_en')
-                    ->exists();
-                if ($avalActivo) {
+                $aval = Aval::ultimoCreditoActivo($avalCurp);
+                if ($aval && $aval->credito && in_array($aval->credito->estado, ['activo', 'vigente'])) {
                     throw new \Exception('El aval ya está asociado a un crédito activo.');
                 }
 

--- a/app/Models/Aval.php
+++ b/app/Models/Aval.php
@@ -21,4 +21,12 @@ class Aval extends Model
     {
         return $this->hasMany(DocumentoAval::class);
     }
+
+    public static function ultimoCreditoActivo(string $curp)
+    {
+        return static::where('CURP', $curp)
+            ->with('credito')
+            ->latest('creado_en')
+            ->first();
+    }
 }


### PR DESCRIPTION
## Summary
- add Aval::ultimoCreditoActivo to fetch latest guarantor with credit
- ensure recredit checks latest guarantor and rejects if credit active

## Testing
- `composer test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e1c252708325a05b6610def94bf8