### PR TITLE
Show full client name on venta list

### DIFF
--- a/resources/views/mobile/promotor/venta/venta.blade.php
+++ b/resources/views/mobile/promotor/venta/venta.blade.php
@@ -50,12 +50,15 @@
                 </div>
                 <div class="space-y-2">
                     @foreach ($clientes as $cliente)
+                        @php
+                            $nombreCompleto = trim("{$cliente->nombre} {$cliente->apellido_p} {$cliente->apellido_m}");
+                        @endphp
                         <div class="grid grid-cols-7 items-center gap-2 bg-white rounded-xl border border-gray-100 px-3 py-2.5 shadow-sm">
                             <div class="col-span-4 flex items-center gap-2">
                                 <span class="inline-flex shrink-0 w-6 h-6 rounded-full bg-indigo-100 text-indigo-700 items-center justify-center text-[11px] font-bold">
                                     {{ $loop->iteration }}
                                 </span>
-                                <p class="text-sm font-medium text-gray-900 truncate">{{ $cliente->nombre }}</p>
+                                <p class="text-sm font-medium text-gray-900 truncate">{{ $nombreCompleto }}</p>
                             </div>
                             <div class="col-span-3 text-right">
                                 <p class="text-sm font-semibold text-gray-900">{{ money_mx($cliente->credito->monto_total ?? $cliente->monto_maximo) }}</p>


### PR DESCRIPTION
## Summary
- Show each client's full name in sales summary

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e7e0aec48325941a33a2a4561d98