### PR TITLE
Adjust client name fields and history links in mobile cartera views

### DIFF
--- a/resources/views/mobile/promotor/cartera/activa.blade.php
+++ b/resources/views/mobile/promotor/cartera/activa.blade.php
@@ -17,7 +17,7 @@
                 >
                 <div>
                     <p class="text-lg font-semibold text-gray-800">
-                        {{ $c['apellido'] ?? $c->apellido ?? '' }} {{ $c['nombre'] ?? $c->nombre ?? '' }}
+                        {{ ($c['apellido_p'] ?? $c->apellido_p ?? '') }} {{ ($c['apellido_m'] ?? $c->apellido_m ?? '') }} {{ ($c['nombre'] ?? $c->nombre ?? '') }}
                     </p>
                     <p class="text-base text-gray-600">
                         Sem {{ $c['semana_credito'] ?? $c->semana_credito ?? '' }}
@@ -35,11 +35,11 @@
                 <button
                     class="w-8 h-8 border-2 border-green-500 text-green-500 rounded-full flex items-center justify-center"
                     title="Registrar pago"
-                    @click="$store.calc.open(@js(($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))"
+                    @click="$store.calc.open(@js(($c['apellido_p'] ?? $c->apellido_p ?? '') . ' ' . ($c['apellido_m'] ?? $c->apellido_m ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))"
                 >
                     $
                 </button>
-                <a href="{{ route('mobile.promotor.cliente_historial') }}"
+                <a href="{{ route('mobile.' . $role . '.cliente_historial', $c['id'] ?? $c->id) }}"
                    class="w-8 h-8 border-2 border-yellow-500 text-yellow-500 rounded-full flex items-center justify-center"
                    title="Historial"
                 >

--- a/resources/views/mobile/promotor/cartera/inactiva.blade.php
+++ b/resources/views/mobile/promotor/cartera/inactiva.blade.php
@@ -3,7 +3,7 @@
         <li class="flex items-center justify-between py-2">
             <div class="flex-1">
                 <p class="text-base font-semibold text-gray-800">
-                    {{ $c['apellido'] ?? $c->apellido ?? '' }} {{ $c['nombre'] ?? $c->nombre ?? '' }}
+                    {{ ($c['apellido_p'] ?? $c->apellido_p ?? '') }} {{ ($c['apellido_m'] ?? $c->apellido_m ?? '') }} {{ ($c['nombre'] ?? $c->nombre ?? '') }}
                 </p>
             </div>
 

--- a/resources/views/mobile/promotor/cartera/vencida.blade.php
+++ b/resources/views/mobile/promotor/cartera/vencida.blade.php
@@ -17,7 +17,7 @@
                 >
                 <div>
                     <p class="text-base font-semibold text-gray-800">
-                        {{ ($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '') }}
+                        {{ ($c['apellido_p'] ?? $c->apellido_p ?? '') }} {{ ($c['apellido_m'] ?? $c->apellido_m ?? '') }} {{ ($c['nombre'] ?? $c->nombre ?? '') }}
                     </p>
                 </div>
             </div>
@@ -32,10 +32,17 @@
                 <button
                     class="w-8 h-8 border-2 border-green-500 text-green-500 rounded-full flex items-center justify-center"
                     title="Registrar pago"
-                    @click="$store.calc.open(@js(($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))"
+                    @click="$store.calc.open(@js(($c['apellido_p'] ?? $c->apellido_p ?? '') . ' ' . ($c['apellido_m'] ?? $c->apellido_m ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))"
                 >
                     $
                 </button>
+
+                <a href="{{ route('mobile.' . $role . '.cliente_historial', $c['id'] ?? $c->id) }}"
+                   class="w-8 h-8 border-2 border-yellow-500 text-yellow-500 rounded-full flex items-center justify-center"
+                   title="Historial"
+                >
+                    H
+                </a>
 
                 <button
                    class="w-8 h-8 border-2 border-blue-500 text-blue-500 rounded-full flex items-center justify-center"


### PR DESCRIPTION
## Summary
- Display full names with paternal and maternal surnames in active, overdue, and inactive client lists
- Use dynamic client history route with role and id in active and overdue lists
- Prepare calculator with updated full names

## Testing
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68c4ee69a1848325a5f6ffd4a3e93ddb