### PR TITLE
Include cliente parameter in mobile history routes

### DIFF
--- a/app/Http/Controllers/Mobile/EjecutivoController.php
+++ b/app/Http/Controllers/Mobile/EjecutivoController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Mobile;
 
 use App\Http\Controllers\Controller;
+use App\Models\Cliente;
 
 class EjecutivoController extends Controller
 {
@@ -36,8 +37,8 @@ class EjecutivoController extends Controller
         return view('mobile.ejecutivo.cartera.cartera');
     }
 
-    public function cliente_historial()
+    public function cliente_historial(Cliente $cliente)
     {
-        return view('mobile.ejecutivo.cartera.cliente_historial');
+        return view('mobile.ejecutivo.cartera.cliente_historial', compact('cliente'));
     }
 }

--- a/app/Http/Controllers/Mobile/SupervisorController.php
+++ b/app/Http/Controllers/Mobile/SupervisorController.php
@@ -92,9 +92,9 @@ class SupervisorController extends Controller
         return view('mobile.supervisor.cartera.reporte');
     }
 
-    public function cliente_historial()
+    public function cliente_historial(Cliente $cliente)
     {
-        return view('mobile.supervisor.cartera.cliente_historial');
+        return view('mobile.supervisor.cartera.cliente_historial', compact('cliente'));
     }
 
     public function cartera_activa()

--- a/resources/views/mobile/supervisor/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_falla.blade.php
@@ -11,6 +11,7 @@
         $clientes = collect(range(1, rand(4, 7)))->map(function () use ($faker, $estatusFalla) {
             $estatus = collect($estatusFalla)->random();
             return [
+                'id'      => $faker->unique()->numberBetween(1, 1000),
                 'nombre'  => $faker->firstName . ' ' . $faker->lastName,
                 'monto'   => $faker->numberBetween(500, 8000),
                 'estatus' => $estatus,
@@ -82,7 +83,7 @@
                                 </button>
 
                                 {{-- Botón Historial --}}
-                                <a href='{{ route("mobile.$role.cliente_historial") }}'
+                                <a href='{{ route("mobile.$role.cliente_historial", $cliente["id"]) }}'
                                    class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white font-bold hover:bg-amber-600 shadow-sm">
                                     H
                                 </a>

--- a/resources/views/mobile/supervisor/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_vencida.blade.php
@@ -11,6 +11,7 @@
         $clientes = collect(range(1, rand(4, 7)))->map(function () use ($faker, $estatusVencido) {
             $estatus = collect($estatusVencido)->random();
             return [
+                'id'      => $faker->unique()->numberBetween(1, 1000),
                 'nombre'  => $faker->firstName . ' ' . $faker->lastName,
                 'monto'   => $faker->numberBetween(1000, 10000),
                 'estatus' => $estatus,
@@ -85,7 +86,7 @@
                                 </button>
 
                                 {{-- Botón Historial --}}
-                                <a href='{{ route("mobile.$role.cliente_historial") }}'
+                                <a href='{{ route("mobile.$role.cliente_historial", $cliente["id"]) }}'
                                    class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white font-bold hover:bg-amber-600 shadow-sm"
                                    title="Historial">
                                     H

--- a/resources/views/mobile_legacy/promotor/cartera/activa.blade.php
+++ b/resources/views/mobile_legacy/promotor/cartera/activa.blade.php
@@ -23,7 +23,7 @@
                  @click="$store.calc.open(@js(($c['apellido'] ?? $c->apellido ?? '') . ' ' . ($c['nombre'] ?? $c->nombre ?? '')))">
                     $
                 </button>
-                <a href="{{route("mobile.$role.cliente_historial")}}"
+                <a href="{{ route("mobile.$role.cliente_historial", $c['id'] ?? $c->id) }}"
                    class="w-8 h-8 border-2 border-yellow-500 text-yellow-500 rounded-full flex items-center justify-center"
                    title="Historial">
                     H

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera_falla.blade.php
@@ -11,6 +11,7 @@
         $clientes = collect(range(1, rand(4, 7)))->map(function () use ($faker, $estatusFalla) {
             $estatus = collect($estatusFalla)->random();
             return [
+                'id'      => $faker->unique()->numberBetween(1, 1000),
                 'nombre'  => $faker->firstName . ' ' . $faker->lastName,
                 'monto'   => $faker->numberBetween(500, 8000),
                 'estatus' => $estatus,
@@ -82,7 +83,7 @@
                                 </button>
 
                                 {{-- Botón Historial --}}
-                                <a href='{{ route("mobile.$role.cliente_historial") }}'
+                                <a href='{{ route("mobile.$role.cliente_historial", $cliente["id"]) }}'
                                    class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white font-bold hover:bg-amber-600 shadow-sm">
                                     H
                                 </a>

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera_vencida.blade.php
@@ -11,6 +11,7 @@
         $clientes = collect(range(1, rand(4, 7)))->map(function () use ($faker, $estatusVencido) {
             $estatus = collect($estatusVencido)->random();
             return [
+                'id'      => $faker->unique()->numberBetween(1, 1000),
                 'nombre'  => $faker->firstName . ' ' . $faker->lastName,
                 'monto'   => $faker->numberBetween(1000, 10000),
                 'estatus' => $estatus,
@@ -85,7 +86,7 @@
                                 </button>
 
                                 {{-- Botón Historial --}}
-                                <a href='{{ route("mobile.$role.cliente_historial") }}'
+                                <a href='{{ route("mobile.$role.cliente_historial", $cliente["id"]) }}'
                                    class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white font-bold hover:bg-amber-600 shadow-sm"
                                    title="Historial">
                                     H

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,7 +61,7 @@ Route::middleware(['auth','verified'])->group(function () {
                       Route::get('ingresar-cliente',  'ingresar_cliente')  ->name('ingresar_cliente');
                       Route::post('ingresar-cliente', 'storeCliente')      ->name('store_cliente');
                       Route::post('recredito',        'storeRecredito')    ->name('store_recredito');
-                      Route::get('cliente-historial', 'cliente_historial') ->name('cliente_historial');
+                      Route::get('cliente-historial/{cliente}', 'cliente_historial') ->name('cliente_historial');
                       Route::post('enviar-ventas',    'enviarVentas')      ->name('enviar_ventas');
                   });
 
@@ -75,7 +75,7 @@ Route::middleware(['auth','verified'])->group(function () {
                       Route::get('objetivo',          'objetivo')          ->name('objetivo');
                       Route::get('solicitar-venta',   'solicitar_venta')   ->name('solicitar_venta');
                       Route::get('ingresar-cliente',  'ingresar_cliente')  ->name('ingresar_cliente');
-                      Route::get('cliente-historial', 'cliente_historial') ->name('cliente_historial');
+                      Route::get('cliente-historial/{cliente}', 'cliente_historial') ->name('cliente_historial');
                   });
 
              Route::prefix('supervisor')
@@ -89,7 +89,7 @@ Route::middleware(['auth','verified'])->group(function () {
                       Route::get('reporte',           'reporte')           ->name('reporte');
                       Route::get('solicitar-venta',   'solicitar_venta')   ->name('solicitar_venta');
                       Route::get('ingresar-cliente',  'ingresar_cliente')  ->name('ingresar_cliente');
-                      Route::get('cliente-historial', 'cliente_historial') ->name('cliente_historial');
+                      Route::get('cliente-historial/{cliente}', 'cliente_historial') ->name('cliente_historial');
                       Route::get('cartera-activa',    'cartera_activa')    ->name('cartera_activa');
                       Route::get('cartera-vencida',   'cartera_vencida')   ->name('cartera_vencida');
                       Route::get('cartera-inactiva',  'cartera_inactiva')  ->name('cartera_inactiva');


### PR DESCRIPTION
## Summary
- add cliente parameter to mobile route definitions and controller methods
- update supervisor and legacy views to pass client id in history links

## Testing
- `php artisan route:list | grep cliente-historial`
- `APP_KEY=base64:gaWkqSedMJw/vy3aHbzI43fPlNb7kggOAURtmF9WxCU= php artisan test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ef2766508325bc7895b2b6042011