### PR TITLE
Add supervisor promotor client listings

### DIFF
--- a/app/Http/Controllers/Mobile/SupervisorController.php
+++ b/app/Http/Controllers/Mobile/SupervisorController.php
@@ -84,7 +84,25 @@ class SupervisorController extends Controller
 
     public function cartera()
     {
-        return view('mobile.supervisor.cartera.cartera');
+        $supervisor = auth()->user()->supervisor;
+        $promotores = $supervisor?->promotores()
+            ->select('id', 'nombre', 'apellido_p', 'apellido_m')
+            ->get();
+
+        return view('mobile.supervisor.cartera.cartera', compact('promotores'));
+    }
+
+    public function carteraPromotor(Promotor $promotor)
+    {
+        $supervisor = auth()->user()->supervisor;
+
+        abort_unless($promotor->supervisor_id === $supervisor->id, 403);
+
+        $clientes = Cliente::where('promotor_id', $promotor->id)
+            ->with('credito')
+            ->get();
+
+        return view('mobile.supervisor.cartera.promotor', compact('promotor', 'clientes'));
     }
     
     public function reporte()

--- a/resources/views/mobile/supervisor/cartera/cartera.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera.blade.php
@@ -1,149 +1,34 @@
-{{-- resources/views/mobile/supervisor/dashboard.blade.php (o donde lo necesites) --}}
-@php
-    use Faker\Factory as Faker;
-
-    /** @var string $role */
-    $role = $role ?? 'promotor';
-    $faker = Faker::create('es_MX');
-
-    // Supervisor y métricas
-    $nombre_supervisor = $faker->name();
-    $cartera_activa    = $faker->randomFloat(2, 80000, 250000);
-    $cartera_falla     = $faker->randomFloat(2,  5000,  60000);
-    $cartera_vencida   = $faker->randomFloat(2, 10000, 120000);
-    $cartera_inactivaP = $faker->numberBetween(1, 35); // porcentaje
-
-    // Porcentaje de fallo (ajusta la fórmula si quieres otra)
-    $porcentaje_fallo  = $cartera_activa > 0 ? round(($cartera_falla / $cartera_activa) * 100, 2) : 0;
-
-    // Promotores
-    $promotores = collect(range(1, 8))->map(fn($i) => [
-        'name'     => $faker->name(),
-        'progress' => $faker->numberBetween(5, 100), // %
-    ]);
-    function money_mx($v){ return '$' . number_format($v, 2, '.', ','); }
-@endphp
-
-<x-layouts.mobile.mobile-layout title="Panel Supervisor">
+<x-layouts.mobile.mobile-layout title="Cartera Supervisor">
   <div class="mx-auto w-[22rem] sm:w-[26rem] p-4 sm:p-6 space-y-6">
-
-    {{-- =======================
-         DIV1: Resumen
-       ======================= --}}
-    <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
-      <div class="p-5 space-y-4">
-        <h2 class="text-base font-bold text-gray-900">Resumen</h2>
-
-        <div class="space-y-3">
-          <div class="flex items-center justify-between">
-            <span class="text-sm text-gray-600">Supervisor:</span>
-            <span class="text-sm font-semibold text-gray-900">{{ $nombre_supervisor }}</span>
-          </div>
-
-          <div class="flex items-center justify-between">
-            <span class="text-sm text-gray-600">Cartera Activa:</span>
-            <div class="flex items-center gap-2">
-              <span class="text-sm font-semibold text-gray-900">{{ money_mx($cartera_activa) }}</span>
-              <a href="{{ route("mobile.$role.cartera_activa") }}"
-                 class="inline-flex items-center justify-center w-6 h-6 text-xs font-bold rounded-full bg-blue-600 text-white hover:bg-blue-700 transition"
-                 title="Detalles">D</a>
-            </div>
-          </div>
-
-          <div class="flex items-center justify-between">
-            <span class="text-sm text-gray-600">Falla Actual:</span>
-            <div class="flex items-center gap-2">
-              <span class="text-xs px-2 py-0.5 rounded-full bg-yellow-100 text-yellow-800 ring-1 ring-yellow-200">
-                {{ $porcentaje_fallo }}%
-              </span>
-              <span class="text-sm font-semibold text-gray-900">{{ money_mx($cartera_falla) }}</span>
-              <a href="{{ route("mobile.$role.cartera_falla") }}"
-                 class="inline-flex items-center justify-center w-6 h-6 text-xs font-bold rounded-full bg-blue-600 text-white hover:bg-blue-700 transition"
-                 title="Detalles">D</a>
-            </div>
-          </div>
-
-          <div class="flex items-center justify-between">
-            <span class="text-sm text-gray-600">Cartera Vencida:</span>
-            <div class="flex items-center gap-2">
-              <span class="text-sm font-semibold text-gray-900">{{ money_mx($cartera_vencida) }}</span>
-              <a href="{{ route("mobile.$role.cartera_vencida") }}"
-                 class="inline-flex items-center justify-center w-6 h-6 text-xs font-bold rounded-full bg-blue-600 text-white hover:bg-blue-700 transition"
-                 title="Detalles">D</a>
-            </div>
-          </div>
-
-          <div class="flex items-center justify-between">
-            <span class="text-sm text-gray-600">Cartera Inactiva:</span>
-            <div class="flex items-center gap-2">
-              <span class="text-sm font-semibold text-gray-900">{{ $cartera_inactivaP }}%</span>
-              <a href="{{ route("mobile.$role.cartera_inactiva") }}"
-                 class="inline-flex items-center justify-center w-6 h-6 text-xs font-bold rounded-full bg-blue-600 text-white hover:bg-blue-700 transition"
-                 title="Detalles">D</a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    {{-- =======================
-         DIV2: Promotores
-       ======================= --}}
     <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
       <div class="p-5">
         <h2 class="text-base font-bold text-gray-900 mb-3">Promotores</h2>
-
         <div class="space-y-3">
-          @foreach($promotores as $i => $p)
-            <a href="{{ route('mobile.promotor.cartera', ['id' => $loop->iteration]) }}"
-              class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">
-              <div class="flex items-center justify-between">
-                <div class="flex items-center gap-2">
-                  <span class="inline-flex items-center justify-center w-6 h-6 text-[11px] font-bold rounded-full bg-indigo-100 text-indigo-700">
-                    {{ $loop->iteration }}
-                  </span>
-                  <span class="text-sm font-semibold text-gray-900">{{ $p['name'] }}</span>
-                </div>
-              </div>
-
-              {{-- Progress bar --}}
-              <div class="mt-2">
-                <div class="h-2 w-full rounded-full bg-gray-200 overflow-hidden">
-                  <div class="h-2 rounded-full bg-gradient-to-r from-indigo-600 to-blue-500"
-                        style="width: {{ $p['progress'] }}%"></div>
-                </div>
-                <div class="mt-1 flex items-center justify-between text-[11px] text-gray-600">
-                  <span>Progreso</span>
-                  <span class="font-semibold">{{ $p['progress'] }}%</span>
-                </div>
+          @forelse($promotores as $p)
+            <a href="{{ route('mobile.supervisor.cartera_promotor', $p->id) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">
+              <div class="flex items-center gap-2">
+                <span class="text-sm font-semibold text-gray-900">{{ $p->nombre }} {{ $p->apellido_p }} {{ $p->apellido_m }}</span>
               </div>
             </a>
-          @endforeach
+          @empty
+            <p class="text-sm text-gray-500">No hay promotores registrados.</p>
+          @endforelse
         </div>
       </div>
     </section>
 
-    {{-- =======================
-         DIV3: Acciones
-       ======================= --}}
     <section class="grid grid-cols-3 gap-3">
-      <a href="{{ url()->previous() }}"
-          class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
-          Regresar
+      <a href="{{ url()->previous() }}" class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
+        Regresar
       </a>
 
-      {{-- Actualizar: recarga la misma URL --}}
-      <a href="{{ url()->current() }}"
-         class="inline-flex items-center justify-center rounded-xl bg-blue-600 text-white text-sm font-semibold px-3 py-2 hover:bg-blue-700 shadow">
+      <a href="{{ url()->current() }}" class="inline-flex items-center justify-center rounded-xl bg-blue-600 text-white text-sm font-semibold px-3 py-2 hover:bg-blue-700 shadow">
         Actualizar
       </a>
 
-      {{-- Reporte: ajusta la ruta a la que uses para reportes --}}
-      <a href="{{ route("mobile.$role.reporte") }}"
-         class="inline-flex items-center justify-center rounded-xl bg-indigo-600 text-white text-sm font-semibold px-3 py-2 hover:bg-indigo-700 shadow">
+      <a href="{{ route('mobile.supervisor.reporte') }}" class="inline-flex items-center justify-center rounded-xl bg-indigo-600 text-white text-sm font-semibold px-3 py-2 hover:bg-indigo-700 shadow">
         Reporte
       </a>
     </section>
-
   </div>
 </x-layouts.mobile.mobile-layout>

--- a/resources/views/mobile/supervisor/cartera/promotor.blade.php
+++ b/resources/views/mobile/supervisor/cartera/promotor.blade.php
@@ -1,0 +1,37 @@
+<x-layouts.mobile.mobile-layout title="Cartera Promotor">
+  <div class="mx-auto w-[22rem] sm:w-[26rem] p-4 sm:p-6 space-y-6">
+    <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
+      <div class="p-5">
+        <h2 class="text-base font-bold text-gray-900 mb-3">{{ $promotor->nombre }} {{ $promotor->apellido_p }} {{ $promotor->apellido_m }}</h2>
+        <div class="space-y-3">
+          @forelse($clientes as $c)
+            <a href="{{ route('mobile.supervisor.cliente_historial', $c->id) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">
+              <div class="flex items-center justify-between">
+                <span class="text-sm font-semibold text-gray-900">{{ $c->nombre }} {{ $c->apellido_p }} {{ $c->apellido_m }}</span>
+                @if($c->credito)
+                  <span class="text-xs text-gray-500">Crédito #{{ $c->credito->id }}</span>
+                @endif
+              </div>
+            </a>
+          @empty
+            <p class="text-sm text-gray-500">No hay clientes registrados.</p>
+          @endforelse
+        </div>
+      </div>
+    </section>
+
+    <section class="grid grid-cols-3 gap-3">
+      <a href="{{ route('mobile.supervisor.cartera') }}" class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
+        Regresar
+      </a>
+
+      <a href="{{ url()->current() }}" class="inline-flex items-center justify-center rounded-xl bg-blue-600 text-white text-sm font-semibold px-3 py-2 hover:bg-blue-700 shadow">
+        Actualizar
+      </a>
+
+      <a href="{{ route('mobile.supervisor.reporte') }}" class="inline-flex items-center justify-center rounded-xl bg-indigo-600 text-white text-sm font-semibold px-3 py-2 hover:bg-indigo-700 shadow">
+        Reporte
+      </a>
+    </section>
+  </div>
+</x-layouts.mobile.mobile-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,8 +55,8 @@ Route::middleware(['auth','verified'])->group(function () {
                   ->group(function () {
                       Route::get('/',                 'index')             ->name('index');
                       Route::get('venta',             'venta')             ->name('venta');
-                      Route::get('cartera',           'cartera')           ->name('cartera');
-                      Route::get('objetivo',          'objetivo')          ->name('objetivo');
+                        Route::get('cartera',           'cartera')           ->name('cartera');
+                        Route::get('objetivo',          'objetivo')          ->name('objetivo');
                       Route::get('solicitar-venta',   'solicitar_venta')   ->name('solicitar_venta');
                       Route::get('ingresar-cliente',  'ingresar_cliente')  ->name('ingresar_cliente');
                       Route::post('ingresar-cliente', 'storeCliente')      ->name('store_cliente');
@@ -71,21 +71,22 @@ Route::middleware(['auth','verified'])->group(function () {
                   ->group(function () {
                       Route::get('/',                 'index')             ->name('index');
                       Route::get('venta',             'venta')             ->name('venta');
-                      Route::get('cartera',           'cartera')           ->name('cartera');
-                      Route::get('objetivo',          'objetivo')          ->name('objetivo');
+                        Route::get('cartera',           'cartera')           ->name('cartera');
+                        Route::get('objetivo',          'objetivo')          ->name('objetivo');
                       Route::get('solicitar-venta',   'solicitar_venta')   ->name('solicitar_venta');
                       Route::get('ingresar-cliente',  'ingresar_cliente')  ->name('ingresar_cliente');
                       Route::get('cliente-historial/{cliente}', 'cliente_historial') ->name('cliente_historial');
                   });
 
-             Route::prefix('supervisor')
-                  ->name('supervisor.')
-                  ->controller(SupervisorController::class)
-                  ->group(function () {
-                      Route::get('/',                 'index')             ->name('index');
-                      Route::get('venta',             'venta')             ->name('venta');
-                      Route::get('cartera',           'cartera')           ->name('cartera');
-                      Route::get('objetivo',          'objetivo')          ->name('objetivo');
+               Route::prefix('supervisor')
+                    ->name('supervisor.')
+                    ->controller(SupervisorController::class)
+                    ->group(function () {
+                        Route::get('/',                 'index')             ->name('index');
+                        Route::get('venta',             'venta')             ->name('venta');
+                        Route::get('cartera',           'cartera')           ->name('cartera');
+                        Route::get('cartera/promotor/{promotor}', 'carteraPromotor')->name('cartera_promotor');
+                        Route::get('objetivo',          'objetivo')          ->name('objetivo');
                       Route::get('reporte',           'reporte')           ->name('reporte');
                       Route::get('solicitar-venta',   'solicitar_venta')   ->name('solicitar_venta');
                       Route::get('ingresar-cliente',  'ingresar_cliente')  ->name('ingresar_cliente');


### PR DESCRIPTION
## Summary
- Load authenticated supervisor's promotores in cartera
- Add view and route to show a promotor's clients
- Replace Faker data with real promotores in supervisor cartera view

## Testing
- `php artisan test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c61b8e0d448325bb9a8043aafed6b9