### PR TITLE
Restrict promotor access to authorized supervisor

### DIFF
--- a/app/Http/Controllers/Mobile/SupervisorController.php
+++ b/app/Http/Controllers/Mobile/SupervisorController.php
@@ -101,7 +101,9 @@ class SupervisorController extends Controller
     {
         $supervisor = auth()->user()->supervisor;
 
-        abort_unless($supervisor && $promotor->supervisor_id === $supervisor->id, 403);
+        abort_if(!$supervisor, 403);
+
+        abort_unless($promotor->supervisor_id === $supervisor->id, 403);
 
         $clientes = Cliente::where('promotor_id', $promotor->id)
             ->with('credito')


### PR DESCRIPTION
## Summary
- Ensure mobile supervisor controller requires authenticated supervisor
- Prevent promotor client lookup unless assigned to supervisor

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6280e73408325824b6fcb155883ef