### PR TITLE
Implement credit decision handling in supervisor workflow

### DIFF
--- a/resources/views/mobile/supervisor/venta/clientes_prospectados.blade.php
+++ b/resources/views/mobile/supervisor/venta/clientes_prospectados.blade.php
@@ -259,8 +259,7 @@
         actionInProgress: null,
         maxGarantias: 8,
         postUrl: '{{ route('mobile.supervisor.nuevo_cliente.store') }}',
-        approveUrlTemplate: @js(route('mobile.supervisor.clientes_prospectados.aprobar', ['cliente' => '__CLIENTE_ID__'])),
-        rejectUrlTemplate: @js(route('mobile.supervisor.clientes_prospectados.rechazar', ['cliente' => '__CLIENTE_ID__'])),
+        registrarCreditoUrlTemplate: @js(route('mobile.supervisor.clientes_prospectados.registrar_credito', ['cliente' => '__CLIENTE_ID__'])),
         csrfToken: '{{ csrf_token() }}',
         selected: {},
         form: {},
@@ -672,13 +671,16 @@
           this.actionInProgress = type;
           this.modalFeedback = { show: false, type: 'success', message: '' };
           try {
+            const accion = type === 'approve' ? 'aprobar' : 'rechazar';
             const response = await fetch(url, {
               method: 'POST',
               headers: {
                 'Accept': 'application/json',
                 'X-CSRF-TOKEN': this.csrfToken,
                 'X-Requested-With': 'XMLHttpRequest',
+                'Content-Type': 'application/json',
               },
+              body: JSON.stringify({ accion }),
             });
             const data = await response.json().catch(() => ({}));
             if (!response.ok) {
@@ -710,12 +712,12 @@
         },
         async aceptar() {
           if (!this.selected?.id) return;
-          const url = this.approveUrlTemplate.replace('__CLIENTE_ID__', this.selected.id);
+          const url = this.registrarCreditoUrlTemplate.replace('__CLIENTE_ID__', this.selected.id);
           await this.handleProspectoAction('approve', url, 'Cliente supervisado correctamente.', 'No se pudo supervisar el cliente.');
         },
         async rechazar() {
           if (!this.selected?.id) return;
-          const url = this.rejectUrlTemplate.replace('__CLIENTE_ID__', this.selected.id);
+          const url = this.registrarCreditoUrlTemplate.replace('__CLIENTE_ID__', this.selected.id);
           await this.handleProspectoAction('reject', url, 'Cliente rechazado correctamente.', 'No se pudo rechazar el cliente.');
         },
         async submitForm() {
@@ -788,8 +790,6 @@
             this.saving = false;
           }
         },
-        aceptar() { console.log('ACEPTAR', this.selected); this.closeModal(); },
-        rechazar() { console.log('RECHAZAR', this.selected); this.closeModal(); },
         formatCurrency(value) {
           const number = Number(value || 0);
           return new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN', minimumFractionDigits: 2 }).format(number);

--- a/routes/web.php
+++ b/routes/web.php
@@ -101,8 +101,7 @@ Route::middleware(['auth','verified'])->group(function () {
                       Route::get('reacreditacion',    'reacreditacion')    ->name('reacreditacion');
                       Route::get('clientes-prospectados',    'clientes_prospectados')    ->name('clientes_prospectados');
                       Route::post('clientes-prospectados/formulario', [NuevoClienteController::class, 'store'])->name('nuevo_cliente.store');
-                      Route::post('clientes-prospectados/{cliente}/aprobar', [SupervisorController::class, 'aprobarProspecto'])->name('clientes_prospectados.aprobar');
-                      Route::post('clientes-prospectados/{cliente}/rechazar', [SupervisorController::class, 'rechazarProspecto'])->name('clientes_prospectados.rechazar');
+                      Route::post('clientes-prospectados/{cliente}/registrar-credito', [NuevoClienteController::class, 'RegistrarCredito'])->name('clientes_prospectados.registrar_credito');
                       Route::get('clientes-supervisados',    'clientes_supervisados')    ->name('clientes_supervisados');
                       Route::get('busqueda',          'busqueda')          ->name('busqueda');
                       Route::get('apertura',          'apertura')          ->name('apertura');  


### PR DESCRIPTION
## Summary
- add a RegistrarCredito action to NuevoClienteController that validates the requested action and updates the crédito and cartera statuses in a transaction
- route supervisor prospect approvals/rejections through the new controller action
- update the mobile prospect view to call the unified endpoint with the selected action and remove the previous placeholder handlers

## Testing
- php artisan test *(fails: MissingAppKeyException because APP_KEY is not configured for the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb334436e48325be1ccdac90f1c9db