### PR TITLE
Ensure supervisor promotor routes carry query context

### DIFF
--- a/resources/views/mobile/supervisor/cartera/cartera.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera.blade.php
@@ -55,7 +55,7 @@
 
         <div class="space-y-3">
           @forelse($promotores as $p)
-            <a href="{{ route('mobile.promotor.cartera', $p->id) }}"
+            <a href="{{ route('mobile.promotor.cartera', array_merge($supervisorContextQuery ?? [], ['promotor' => $p->id])) }}"
                class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">
               <div class="flex items-center justify-between">
                 <div class="flex items-center gap-2">

--- a/resources/views/mobile/supervisor/venta/venta.blade.php
+++ b/resources/views/mobile/supervisor/venta/venta.blade.php
@@ -86,7 +86,7 @@
                     </div>
                     <div>
                         {{-- <a href="{{ route('mobile.supervisor.cartera_promotor', $p->id) }}" class="px-3 py-1 text-right text-sm font-semibold text-white bg-blue-600 rounded">D</a> --}}
-                        <a href="{{ route('mobile.promotor.venta', ['promotor' => $p['id']]) }}" class="px-3 py-1 text-right text-sm font-semibold text-white bg-blue-600 rounded">D</a>
+                        <a href="{{ route('mobile.promotor.venta', array_merge($supervisorContextQuery ?? [], ['promotor' => $p['id']])) }}" class="px-3 py-1 text-right text-sm font-semibold text-white bg-blue-600 rounded">D</a>
                     </div>
                 </div>
                 <div class="grid grid-cols-2 gap-4 text-xs">


### PR DESCRIPTION
## Summary
- update the supervisor cartera listing to pass the promotor id via query parameters while keeping any supervisor context
- update the supervisor venta promotor detail link to merge the supervisor query context when building the route

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0ff5f18f483258a4aa99702e371b1