### PR TITLE
Implement supervisor context resolver and preserve context in views

### DIFF
--- a/resources/views/mobile/supervisor/cartera/cartera.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera.blade.php
@@ -78,9 +78,9 @@
 
     {{-- ===================== Acciones ===================== --}}
     <section class="grid grid-cols-3 gap-3">
-      {!! $btn(route('mobile.index'), 'Regresar', 'outline-primary') !!}
-      {!! $btn(url()->current(), 'Actualizar', 'primary') !!}
-      {!! $btn(url()->current(), 'Reporte', 'indigo') !!}
+      {!! $btn(route('mobile.index', array_merge($supervisorContextQuery ?? [], [])), 'Regresar', 'outline-primary') !!}
+      {!! $btn(route('mobile.supervisor.cartera', array_merge($supervisorContextQuery ?? [], [])), 'Actualizar', 'primary') !!}
+      {!! $btn(route('mobile.supervisor.reporte', array_merge($supervisorContextQuery ?? [], [])), 'Reporte', 'indigo') !!}
     </section>
 
   </div>

--- a/resources/views/mobile/supervisor/cartera/cartera_activa.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_activa.blade.php
@@ -113,7 +113,7 @@
             {{ $promotoresPaginator->withQueryString()->links() }}
         </div>
         {{-- <a href="{{ url()->previous() }}" --}}
-        <a href="{{ route("mobile.$role.cartera") }}"
+        <a href="{{ route("mobile.$role.cartera", array_merge($supervisorContextQuery ?? [], [])) }}"
         class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
             Regresar
         </a>

--- a/resources/views/mobile/supervisor/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_falla.blade.php
@@ -48,7 +48,7 @@
                                 </button>
 
                                 {{-- Botón Historial --}}
-                                <a href='{{ route("mobile.$role.cliente_historial", $cliente["id"]) }}'
+                                <a href='{{ route("mobile.$role.cliente_historial", array_merge($supervisorContextQuery ?? [], ['cliente' => $cliente["id"]])) }}'
                                    class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white font-bold hover:bg-amber-600 shadow-sm">
                                     H
                                 </a>
@@ -63,7 +63,7 @@
             {{ $promotoresPaginator->withQueryString()->links() }}
         </div>
 
-        <a href="{{ url()->previous() }}"
+        <a href="{{ route("mobile.$role.cartera", array_merge($supervisorContextQuery ?? [], [])) }}"
           class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
           Regresar
         </a>

--- a/resources/views/mobile/supervisor/cartera/cartera_inactiva.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_inactiva.blade.php
@@ -70,7 +70,7 @@
         </div>
 
         {{-- Botón Regresar --}}
-        <a href="{{ url()->previous() }}"
+        <a href="{{ route("mobile.$role.cartera", array_merge($supervisorContextQuery ?? [], [])) }}"
           class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
           Regresar
         </a>

--- a/resources/views/mobile/supervisor/cartera/cartera_resumen.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_resumen.blade.php
@@ -8,7 +8,7 @@
         {!! $statRow('Cartera Activa:', null, '
         <div class="flex items-center gap-2">
             <span class="text-sm font-semibold text-gray-900">'.money_mx($cartera_activa).'</span>'.
-            $pillLink(route('mobile.'.$role.'.cartera_activa'), 'D').'
+            $pillLink(route('mobile.'.$role.'.cartera_activa', array_merge($supervisorContextQuery ?? [], [])), 'D').'
         </div>
         ') !!}
 
@@ -18,21 +18,21 @@
             '.$porcentaje_fallo.'%
             </span>
             <span class="text-sm font-semibold text-gray-900">'.money_mx($cartera_falla).'</span>'.
-            $pillLink(route('mobile.'.$role.'.cartera_falla'), 'D').'
+            $pillLink(route('mobile.'.$role.'.cartera_falla', array_merge($supervisorContextQuery ?? [], [])), 'D').'
         </div>
         ') !!}
 
         {!! $statRow('Cartera Vencida:', null, '
         <div class="flex items-center gap-2">
             <span class="text-sm font-semibold text-gray-900">'.money_mx($cartera_vencida).'</span>'.
-            $pillLink(route('mobile.'.$role.'.cartera_vencida'), 'D').'
+            $pillLink(route('mobile.'.$role.'.cartera_vencida', array_merge($supervisorContextQuery ?? [], [])), 'D').'
         </div>
         ') !!}
 
         {!! $statRow('Cartera Inactiva:', null, '
         <div class="flex items-center gap-2">
             <span class="text-sm font-semibold text-gray-900">'.$cartera_inactivaP.'%</span>'.
-            $pillLink(route('mobile.'.$role.'.cartera_inactiva'), 'D').'
+            $pillLink(route('mobile.'.$role.'.cartera_inactiva', array_merge($supervisorContextQuery ?? [], [])), 'D').'
         </div>
         ') !!}
     </div>

--- a/resources/views/mobile/supervisor/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_vencida.blade.php
@@ -51,7 +51,7 @@
                                 </button>
 
                                 {{-- Botón Historial --}}
-                                <a href='{{ route("mobile.$role.cliente_historial", $cliente["id"]) }}'
+                                <a href='{{ route("mobile.$role.cliente_historial", array_merge($supervisorContextQuery ?? [], ['cliente' => $cliente["id"]])) }}'
                                    class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white font-bold hover:bg-amber-600 shadow-sm"
                                    title="Historial">
                                     H
@@ -68,7 +68,7 @@
         </div>
 
         {{-- Botón Regresar --}}
-        <a href="{{ url()->previous() }}"
+        <a href="{{ route("mobile.$role.cartera", array_merge($supervisorContextQuery ?? [], [])) }}"
           class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
           Regresar
         </a>

--- a/resources/views/mobile/supervisor/cartera/cliente_historial.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cliente_historial.blade.php
@@ -176,7 +176,7 @@
     </div>
 
     {{-- BOTÓN REGRESAR --}}
-    <a href="{{ route('mobile.supervisor.cartera') }}"
+    <a href="{{ route('mobile.supervisor.cartera', array_merge($supervisorContextQuery ?? [], [])) }}"
        class="block w-full bg-blue-800 hover:bg-blue-900 text-white font-semibold py-3 rounded-xl text-center shadow-md transition">REGRESAR</a>
 
     {{-- ===== MODAL FOTOGRAFÍAS ===== --}}

--- a/resources/views/mobile/supervisor/cartera/promotor.blade.php
+++ b/resources/views/mobile/supervisor/cartera/promotor.blade.php
@@ -5,7 +5,7 @@
         <h2 class="text-base font-bold text-gray-900 mb-3">{{ $promotor->nombre }} {{ $promotor->apellido_p }} {{ $promotor->apellido_m }}</h2>
         <div class="space-y-3">
           @forelse($clientes as $c)
-            <a href="{{ route('mobile.supervisor.cliente_historial', $c->id) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">
+            <a href="{{ route('mobile.supervisor.cliente_historial', array_merge($supervisorContextQuery ?? [], ['cliente' => $c->id])) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">
               <div class="flex items-center justify-between">
                 <span class="text-sm font-semibold text-gray-900">{{ $c->nombre }} {{ $c->apellido_p }} {{ $c->apellido_m }}</span>
                 @if($c->credito)
@@ -21,7 +21,7 @@
     </section>
 
     <section class="grid grid-cols-3 gap-3">
-      <a href="{{ route('mobile.supervisor.cartera') }}" class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
+      <a href="{{ route('mobile.supervisor.cartera', array_merge($supervisorContextQuery ?? [], [])) }}" class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
         Regresar
       </a>
 
@@ -29,7 +29,7 @@
         Actualizar
       </a>
 
-      <a href="{{ route('mobile.supervisor.reporte') }}" class="inline-flex items-center justify-center rounded-xl bg-indigo-600 text-white text-sm font-semibold px-3 py-2 hover:bg-indigo-700 shadow">
+      <a href="{{ route('mobile.supervisor.reporte', array_merge($supervisorContextQuery ?? [], [])) }}" class="inline-flex items-center justify-center rounded-xl bg-indigo-600 text-white text-sm font-semibold px-3 py-2 hover:bg-indigo-700 shadow">
         Reporte
       </a>
     </section>

--- a/resources/views/mobile/supervisor/venta/venta.blade.php
+++ b/resources/views/mobile/supervisor/venta/venta.blade.php
@@ -54,14 +54,14 @@
                     <p class="text-gray-500 text-sm">Prospectados</p>
                     <p class="text-xl font-bold">{{ $clientesProspectados }}</p>
                 </div>
-                <a href="{{ route("mobile.$role.clientes_prospectados") }}" class="px-3 py-1 text-sm font-semibold text-white bg-blue-600 rounded">D</a>
+                <a href="{{ route("mobile.$role.clientes_prospectados", array_merge($supervisorContextQuery ?? [], [])) }}" class="px-3 py-1 text-sm font-semibold text-white bg-blue-600 rounded">D</a>
             </li>
             <li class="flex items-center justify-between py-2">
                 <div>
                     <p class="text-gray-500 text-sm">Por Supervisar</p>
                     <p class="text-xl font-bold">{{ $clientesPorSupervisar }}</p>
                 </div>
-                <a href="{{ route("mobile.$role.clientes_supervisados") }}" class="px-3 py-1 text-sm font-semibold text-white bg-blue-600 rounded">D</a>
+                <a href="{{ route("mobile.$role.clientes_supervisados", array_merge($supervisorContextQuery ?? [], [])) }}" class="px-3 py-1 text-sm font-semibold text-white bg-blue-600 rounded">D</a>
             </li>
         </ul>
     </div>
@@ -112,11 +112,11 @@
     </div>
 
     {{-- BotÃ³n regresar --}}
-    <a href="{{ route("mobile.$role.horarios") }}"
+    <a href="{{ route("mobile.$role.horarios", array_merge($supervisorContextQuery ?? [], [])) }}"
        class="block text-center py-3 rounded-2xl bg-gradient-to-r from-blue-600 to-blue-500 text-white font-semibold shadow-lg hover:from-blue-700 hover:to-blue-600 transition">
       Horarios
     </a>
-    <a href="{{ route("mobile.$role.index") }}"
+    <a href="{{ route("mobile.$role.index", array_merge($supervisorContextQuery ?? [], [])) }}"
        class="block text-center py-3 rounded-2xl bg-gradient-to-r from-blue-600 to-blue-500 text-white font-semibold shadow-lg hover:from-blue-700 hover:to-blue-600 transition">
       Regresar
     </a>


### PR DESCRIPTION
## Summary
- add a resolveSupervisorContext helper in SupervisorController to manage accessible supervisors, cache the choice and share context with views
- refactor cartera- and client-oriented actions to rely on the new resolver, enforce supervisor ownership and reuse loaded relations
- update supervisor mobile views so navigation links retain the selected supervisor via supervisorContextQuery

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d107bc29488325ad39406597b6c202