### PR TITLE
Implement executive venta metrics and update mobile view

### DIFF
--- a/app/Http/Controllers/EjecutivoController.php
+++ b/app/Http/Controllers/EjecutivoController.php
@@ -8,6 +8,7 @@ use App\Models\Promotor;
 use App\Models\Supervisor;
 use App\Support\RoleHierarchy;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 class EjecutivoController extends Controller
@@ -86,9 +87,60 @@ class EjecutivoController extends Controller
         return view('mobile.ejecutivo.objetivo.objetivo');
     }
 
-    public function venta()
+    public function venta(Request $request)
     {
-        return view('mobile.ejecutivo.venta.venta');
+        $user = $request->user();
+        $primaryRole = RoleHierarchy::resolvePrimaryRole($user);
+
+        $ejecutivo = $this->resolveEjecutivoContext(
+            $primaryRole,
+            $user?->id,
+            (int) $request->query('ejecutivo_id')
+        );
+
+        if ($primaryRole === 'ejecutivo') {
+            abort_if(!$ejecutivo, 403, 'Perfil de ejecutivo no configurado.');
+        }
+
+        $supervisores = $ejecutivo
+            ? Supervisor::query()
+                ->where('ejecutivo_id', $ejecutivo->id)
+                ->with($this->supervisorPromotoresRelationship())
+                ->orderBy('nombre')
+                ->orderBy('apellido_p')
+                ->orderBy('apellido_m')
+                ->get()
+            : collect();
+
+        $supervisores = $supervisores instanceof Collection ? $supervisores : collect($supervisores);
+
+        [$supervisorSummaries, $totals, $ventaFecha] = $this->buildVentaSupervisorMetrics($supervisores);
+
+        $nombre = $ejecutivo?->nombre ?? ($user?->name ?? 'Ejecutivo');
+        $apellido_p = $ejecutivo?->apellido_p;
+        $apellido_m = $ejecutivo?->apellido_m;
+
+        $supervisorContextQuery = array_filter([
+            'ejecutivo_id' => $request->query('ejecutivo_id'),
+        ], fn ($value) => !is_null($value));
+
+        return view('mobile.ejecutivo.venta.venta', [
+            'ejecutivo' => $ejecutivo,
+            'nombre' => $nombre,
+            'apellido_p' => $apellido_p,
+            'apellido_m' => $apellido_m,
+            'fechaVenta' => $ventaFecha,
+            'debeOperativo' => $totals['debeOperativo'],
+            'debeProyectado' => $totals['debeProyectado'],
+            'fallaReal' => $totals['falla'],
+            'cobranza' => $totals['cobranza'],
+            'ventaRegistradaTotal' => $totals['ventaRegistrada'],
+            'fallaPct' => $totals['fallaPct'],
+            'cobranzaPct' => $totals['cobranzaPct'],
+            'supervisores' => $supervisorSummaries,
+            'supervisorContextQuery' => $supervisorContextQuery,
+            'horarios' => collect(),
+        ]);
     }
 
     public function solicitar_venta()
@@ -221,6 +273,161 @@ class EjecutivoController extends Controller
             round($cartera_falla, 2),
             $cartera_inactivaP,
         ];
+    }
+
+    private function supervisorPromotoresRelationship(): array
+    {
+        return [
+            'promotores' => function ($query) {
+                $query->select('id', 'supervisor_id', 'nombre', 'apellido_p', 'apellido_m', 'venta_maxima', 'venta_proyectada_objetivo')
+                    ->with(['clientes' => function ($clienteQuery) {
+                        $clienteQuery->select('id', 'promotor_id');
+                    }])
+                    ->orderBy('nombre');
+            },
+        ];
+    }
+
+    private function buildVentaSupervisorMetrics(Collection $supervisores): array
+    {
+        $supervisores = $supervisores instanceof Collection ? $supervisores : collect($supervisores);
+
+        if ($supervisores->isEmpty()) {
+            $totals = [
+                'debeOperativo' => 0.0,
+                'debeProyectado' => 0.0,
+                'ventaRegistrada' => 0.0,
+                'cobranza' => 0.0,
+                'falla' => 0.0,
+                'fallaPct' => 0.0,
+                'cobranzaPct' => 0.0,
+            ];
+
+            return [collect(), $totals, null];
+        }
+
+        $clienteSupervisorMap = [];
+        $debeOperativoBySupervisor = [];
+        $clienteIds = collect();
+
+        foreach ($supervisores as $supervisor) {
+            $promotores = $supervisor->promotores instanceof Collection ? $supervisor->promotores : collect($supervisor->promotores);
+
+            $debeOperativoBySupervisor[$supervisor->id] = (float) $promotores->sum(function ($promotor) {
+                return (float) ($promotor->venta_maxima ?? 0);
+            });
+
+            $promotores->each(function ($promotor) use ($supervisor, &$clienteSupervisorMap, &$clienteIds) {
+                $clientes = $promotor->clientes instanceof Collection ? $promotor->clientes : collect($promotor->clientes);
+
+                $clientes->each(function ($cliente) use ($supervisor, &$clienteSupervisorMap, &$clienteIds) {
+                    if ($cliente?->id) {
+                        $clienteSupervisorMap[$cliente->id] = $supervisor->id;
+                        $clienteIds->push($cliente->id);
+                    }
+                });
+            });
+        }
+
+        $clienteIds = $clienteIds->unique()->values();
+        $now = Carbon::now();
+
+        $creditos = $clienteIds->isNotEmpty()
+            ? Credito::whereIn('cliente_id', $clienteIds)
+                ->with([
+                    'pagosProyectados' => function ($query) use ($now) {
+                        $query->where('fecha_limite', '<=', $now)
+                            ->with([
+                                'pagosReales.pagoCompleto',
+                                'pagosReales.pagoAnticipo',
+                                'pagosReales.pagoDiferido',
+                            ]);
+                    },
+                ])
+                ->get()
+            : collect();
+
+        $creditosBySupervisor = $creditos->groupBy(function (Credito $credito) use ($clienteSupervisorMap) {
+            return $clienteSupervisorMap[$credito->cliente_id] ?? null;
+        });
+
+        $ventaFecha = null;
+
+        $summaries = $supervisores->map(function (Supervisor $supervisor) use (&$ventaFecha, $debeOperativoBySupervisor, $creditosBySupervisor) {
+            $debeOperativo = $debeOperativoBySupervisor[$supervisor->id] ?? 0.0;
+
+            $creditosSupervisor = $creditosBySupervisor->get($supervisor->id, collect());
+            $creditosSupervisor = $creditosSupervisor instanceof Collection ? $creditosSupervisor : collect($creditosSupervisor);
+
+            $ventaRegistrada = (float) $creditosSupervisor->sum(function (Credito $credito) {
+                return (float) ($credito->monto_total ?? 0);
+            });
+
+            $debeProyectado = (float) $creditosSupervisor->sum(function (Credito $credito) {
+                return (float) $credito->pagosProyectados->sum(function ($pago) {
+                    return (float) ($pago->monto_proyectado ?? 0);
+                });
+            });
+
+            $cobranza = (float) $creditosSupervisor->sum(function (Credito $credito) {
+                return (float) $credito->pagosProyectados->sum(function ($pago) {
+                    return (float) $pago->pagosReales->sum(function ($real) {
+                        return (float) ($real->monto ?? 0);
+                    });
+                });
+            });
+
+            $falla = max(0.0, $debeProyectado - $cobranza);
+
+            $ultimaFecha = $creditosSupervisor->flatMap(function (Credito $credito) {
+                return $credito->pagosProyectados->pluck('fecha_limite');
+            })
+                ->filter()
+                ->map(function ($fecha) {
+                    return $fecha instanceof Carbon ? $fecha : Carbon::parse($fecha);
+                })
+                ->max();
+
+            if ($ultimaFecha && (!$ventaFecha || $ultimaFecha->gt($ventaFecha))) {
+                $ventaFecha = $ultimaFecha->copy();
+            }
+
+            return [
+                'id' => $supervisor->id,
+                'nombre' => trim(collect([
+                    $supervisor->nombre,
+                    $supervisor->apellido_p,
+                    $supervisor->apellido_m,
+                ])->filter()->implode(' ')),
+                'debeOperativo' => round($debeOperativo, 2),
+                'debeProyectado' => round($debeProyectado, 2),
+                'ventaRegistrada' => round($ventaRegistrada, 2),
+                'cobranza' => round($cobranza, 2),
+                'falla' => round($falla, 2),
+                'cobranzaPct' => $debeProyectado > 0 ? round(($cobranza / $debeProyectado) * 100, 2) : 0.0,
+                'fallaPct' => $debeProyectado > 0 ? round(($falla / $debeProyectado) * 100, 2) : 0.0,
+                'fecha' => $ultimaFecha ? $ultimaFecha->format('d/m/Y') : null,
+                'horario' => null,
+            ];
+        })->values();
+
+        $totals = [
+            'debeOperativo' => round((float) $summaries->sum('debeOperativo'), 2),
+            'debeProyectado' => round((float) $summaries->sum('debeProyectado'), 2),
+            'ventaRegistrada' => round((float) $summaries->sum('ventaRegistrada'), 2),
+            'cobranza' => round((float) $summaries->sum('cobranza'), 2),
+            'falla' => round((float) $summaries->sum('falla'), 2),
+        ];
+
+        $totals['cobranzaPct'] = $totals['debeProyectado'] > 0
+            ? round(($totals['cobranza'] / max(1e-6, $totals['debeProyectado'])) * 100, 2)
+            : 0.0;
+
+        $totals['fallaPct'] = $totals['debeProyectado'] > 0
+            ? round(($totals['falla'] / max(1e-6, $totals['debeProyectado'])) * 100, 2)
+            : 0.0;
+
+        return [$summaries, $totals, $ventaFecha];
     }
 
     public function cliente_historial(Cliente $cliente)

--- a/resources/views/mobile/ejecutivo/venta/cards/horarios.blade.php
+++ b/resources/views/mobile/ejecutivo/venta/cards/horarios.blade.php
@@ -2,68 +2,66 @@
 @php
     use Carbon\Carbon;
 
-    if (!defined('__HORARIOS_FAKE_SEED__')) {
-        define('__HORARIOS_FAKE_SEED__', true);
-        mt_srand(20250918);
-    }
-
-    $rndHora = function () {
-        $h = mt_rand(9, 19);
-        $m = [0, 15, 30, 45][mt_rand(0,3)];
-        return str_pad($h, 2, '0', STR_PAD_LEFT) . ':' . str_pad($m, 2, '0', STR_PAD_LEFT);
-    };
-
-    $fechas = [];
-    for ($i = 0; $i < 4; $i++) {
-        $fecha = Carbon::now()->addDays($i)->format('d/m/y');
-        $supervisores = [];
-        for ($s = 1; $s <= mt_rand(2,3); $s++) {
-            $promotores = [];
-            for ($p = 1; $p <= mt_rand(2,4); $p++) {
-                $promotores[] = [
-                    'nombre' => "Promotor {$s}.{$p}",
-                    'hora'   => $rndHora(),
-                ];
-            }
-            $supervisores[] = [
-                'nombre'     => "Supervisor {$s}",
-                'promotores' => $promotores,
-            ];
-        }
-        $fechas[] = [
-            'date'         => $fecha,
-            'supervisores' => $supervisores,
-        ];
-    }
+    $horarios = collect($horarios ?? []);
 @endphp
 
 <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
   <div class="p-5">
     <h2 class="text-base font-bold text-gray-900 mb-3">Horarios de Cobro</h2>
 
-    @foreach($fechas as $fecha)
-      <div class="mb-4">
-        <p class="text-sm font-semibold text-gray-800 mb-2">{{ $fecha['date'] }}</p>
+    @forelse($horarios as $fecha)
+      @php
+          $fechaValor = data_get($fecha, 'date');
+          $fechaTexto = null;
 
-        @foreach($fecha['supervisores'] as $sup)
+          if ($fechaValor instanceof Carbon) {
+              $fechaTexto = $fechaValor->format('d/m/Y');
+          } elseif (!empty($fechaValor)) {
+              try {
+                  $fechaTexto = Carbon::parse($fechaValor)->format('d/m/Y');
+              } catch (\Throwable $e) {
+                  $fechaTexto = (string) $fechaValor;
+              }
+          }
+
+          $supervisoresDia = collect(data_get($fecha, 'supervisores', []));
+      @endphp
+
+      <div class="mb-4">
+        <p class="text-sm font-semibold text-gray-800 mb-2">{{ $fechaTexto ?? 'Sin fecha programada' }}</p>
+
+        @forelse($supervisoresDia as $sup)
+          @php
+              $promotores = collect(data_get($sup, 'promotores', []));
+          @endphp
+
           <div class="rounded-xl border border-gray-100 p-3 mb-2">
-            <p class="text-sm font-semibold text-gray-900">{{ $sup['nombre'] }}</p>
-            <ul class="mt-2 divide-y divide-gray-100">
-              @foreach($sup['promotores'] as $idx => $prom)
-                <li class="py-2 flex items-center justify-between">
-                  <div class="flex items-center gap-2">
-                    <span class="inline-flex items-center justify-center w-6 h-6 text-[11px] font-bold rounded-full bg-indigo-100 text-indigo-700">
-                      {{ $idx+1 }}
-                    </span>
-                    <span class="text-sm text-gray-800">{{ $prom['nombre'] }}</span>
-                  </div>
-                  <span class="text-sm font-semibold text-gray-900">{{ $prom['hora'] }}</span>
-                </li>
-              @endforeach
-            </ul>
+            <p class="text-sm font-semibold text-gray-900">{{ data_get($sup, 'nombre', 'Sin supervisor') }}</p>
+
+            @if($promotores->isNotEmpty())
+              <ul class="mt-2 divide-y divide-gray-100">
+                @foreach($promotores as $idx => $prom)
+                  <li class="py-2 flex items-center justify-between">
+                    <div class="flex items-center gap-2">
+                      <span class="inline-flex items-center justify-center w-6 h-6 text-[11px] font-bold rounded-full bg-indigo-100 text-indigo-700">
+                        {{ $idx + 1 }}
+                      </span>
+                      <span class="text-sm text-gray-800">{{ data_get($prom, 'nombre', 'Sin promotor') }}</span>
+                    </div>
+                    <span class="text-sm font-semibold text-gray-900">{{ data_get($prom, 'hora', '—') }}</span>
+                  </li>
+                @endforeach
+              </ul>
+            @else
+              <p class="text-sm text-gray-500">No hay promotores programados.</p>
+            @endif
           </div>
-        @endforeach
+        @empty
+          <p class="text-sm text-gray-500">No hay supervisores programados.</p>
+        @endforelse
       </div>
-    @endforeach
+    @empty
+      <p class="text-sm text-gray-500">No hay horarios de cobro registrados.</p>
+    @endforelse
   </div>
 </section>


### PR DESCRIPTION
## Summary
- resolve the acting ejecutivo, collect supervisor hierarchies and compute venta/cobranza/falla aggregates
- pass the computed datasets to the mobile ejecutivo venta blade and update supervisor links to keep context
- replace the horarios card demo data with an empty-state aware template that renders provided schedules only

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d10c8051dc83258d0d548c81d2f69e