### PR TITLE
Evitar mutar fecha de crédito al formatear en cliente_historial

### DIFF
--- a/resources/views/mobile/promotor/cartera/cliente_historial.blade.php
+++ b/resources/views/mobile/promotor/cartera/cliente_historial.blade.php
@@ -23,9 +23,12 @@
     $semanaActual = $proximoPago?->semana ?? ($pagos->last()?->semana ?? null);
     $semanaActualTexto = $semanaActual ? 'sem ' . $semanaActual : 'N/A';
 
-    $fechaCredito = optional($credito?->fecha_inicio)
-        ?->locale('es')
-        ->isoFormat('D [de] MMMM [de] YYYY');
+    $fechaCredito = $credito && $credito->fecha_inicio
+        ? $credito->fecha_inicio
+            ?->clone()
+            ?->locale('es')
+            ?->isoFormat('D [de] MMMM [de] YYYY')
+        : null;
 
     $formatCurrency = static function ($value): string {
         return '$' . number_format((float) $value, 2, '.', ',');


### PR DESCRIPTION
## Summary
- evita formatear la fecha de crédito cuando no existe crédito asociado en la vista móvil de historial
- clona la fecha del crédito antes de aplicar `locale` e `isoFormat` para no mutar el atributo original

## Testing
- Manual - Verifiqué que la vista muestra "Sin fecha" cuando el cliente no tiene crédito y la fecha formateada cuando sí existe


------
https://chatgpt.com/codex/tasks/task_e_68d1c649815c832582d9803da7180475