### PR TITLE
Add supervisor prospect navigation controls

### DIFF
--- a/resources/views/mobile/supervisor/venta/clientes_prospectados.blade.php
+++ b/resources/views/mobile/supervisor/venta/clientes_prospectados.blade.php
@@ -236,6 +236,17 @@
         </div>
       </div>
     </template>
+
+    <div class="space-y-3">
+      <a href="{{ route('mobile.supervisor.clientes_prospectados', array_merge($supervisorContextQuery ?? [], [])) }}"
+         class="block text-center py-3 rounded-2xl bg-gradient-to-r from-blue-600 to-blue-500 text-white font-semibold shadow-lg hover:from-blue-700 hover:to-blue-600 transition">
+        Recargar
+      </a>
+      <a href="{{ route('mobile.supervisor.venta', array_merge($supervisorContextQuery ?? [], [])) }}"
+         class="block text-center py-3 rounded-2xl bg-gradient-to-r from-blue-600 to-blue-500 text-white font-semibold shadow-lg hover:from-blue-700 hover:to-blue-600 transition">
+        Regresar a Venta
+      </a>
+    </div>
   </div>
 
   <script>

--- a/tests/Feature/SupervisorClientesProspectadosTest.php
+++ b/tests/Feature/SupervisorClientesProspectadosTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\Ejecutivo;
+use App\Models\Supervisor;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function () {
+    config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
+    $this->withoutVite();
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+it('muestra los botones de recargar y regreso en clientes prospectados', function () {
+    [$user, $supervisor] = createSupervisorClienteProspectadoContext();
+
+    $response = $this->actingAs($user)->get(route('mobile.supervisor.clientes_prospectados'));
+
+    $response
+        ->assertOk()
+        ->assertSeeText('Recargar')
+        ->assertSee(route('mobile.supervisor.clientes_prospectados', ['supervisor' => $supervisor->id]), false)
+        ->assertSeeText('Regresar a Venta')
+        ->assertSee(route('mobile.supervisor.venta', ['supervisor' => $supervisor->id]), false);
+});
+
+/**
+ * @return array{0: User, 1: Supervisor}
+ */
+function createSupervisorClienteProspectadoContext(): array
+{
+    $supervisorRole = Role::firstOrCreate(['name' => 'supervisor', 'guard_name' => 'web']);
+    $ejecutivoRole = Role::firstOrCreate(['name' => 'ejecutivo', 'guard_name' => 'web']);
+
+    $ejecutivoUser = User::factory()->create(['rol' => 'ejecutivo']);
+    $ejecutivoUser->assignRole($ejecutivoRole);
+
+    $ejecutivo = Ejecutivo::create([
+        'user_id' => $ejecutivoUser->id,
+        'nombre' => 'Elena',
+        'apellido_p' => 'Ramírez',
+        'apellido_m' => 'López',
+    ]);
+
+    $user = User::factory()->create(['rol' => 'supervisor']);
+    $user->assignRole($supervisorRole);
+
+    $supervisor = Supervisor::create([
+        'user_id' => $user->id,
+        'ejecutivo_id' => $ejecutivo->id,
+        'nombre' => 'Sonia',
+        'apellido_p' => 'García',
+        'apellido_m' => 'Nava',
+    ]);
+
+    return [$user, $supervisor];
+}


### PR DESCRIPTION
## Summary
- add gradient-styled reload and return buttons to the supervisor prospect list view
- cover the new buttons with a feature test for authenticated supervisors

## Testing
- `APP_KEY=base64:3YfYveoxu48UUfZo0M0RKZ77N8BINU3CzqlMDHviQH4= php artisan test --filter=SupervisorClientesProspectadosTest`

------
https://chatgpt.com/codex/tasks/task_e_68d36a7add2c8325974d3691f051019b