### PR TITLE
Add horario de pago support to cliente workflows

### DIFF
--- a/app/Http/Controllers/ClienteController.php
+++ b/app/Http/Controllers/ClienteController.php
@@ -29,6 +29,7 @@ class ClienteController extends Controller
             'tiene_credito_activo'=> 'required|boolean',
             'cartera_estado'      => 'required|string',
             'monto_maximo'        => 'required|numeric',
+            'horario_de_pago'     => 'required|date_format:H:i',
             'activo'              => 'required|boolean',
         ]);
 
@@ -52,6 +53,7 @@ class ClienteController extends Controller
             'nombre'              => 'required|string',
             'apellido_p'          => 'required|string',
             'apellido_m'          => 'nullable|string',
+            'horario_de_pago'     => 'required|date_format:H:i',
             'tiene_credito_activo'=> 'required|boolean',
             'cartera_estado'      => 'required|string',
             'monto_maximo'        => 'required|numeric',

--- a/app/Http/Controllers/NuevoClienteController.php
+++ b/app/Http/Controllers/NuevoClienteController.php
@@ -93,6 +93,7 @@ class NuevoClienteController extends Controller
             'form.cliente.apellido_p' => ['required', 'string', 'max:100'],
             'form.cliente.apellido_m' => ['required', 'string', 'max:100'],
             'form.cliente.fecha_nacimiento' => ['required', 'date'],
+            'form.cliente.horario_de_pago' => ['required', 'date_format:H:i'],
 
             'form.credito.monto_total' => ['required', 'numeric', 'min:0'],
             'form.credito.periodicidad' => ['required', 'string', 'max:100'],
@@ -198,10 +199,11 @@ class NuevoClienteController extends Controller
         $form = $validated['form'];
 
         try {
-            $cliente = DB::transaction(function () use ($validated, $form, $garantiaFiles) {
-                $cliente = Cliente::lockForUpdate()->findOrFail($validated['cliente_id']);
-                $cliente->fecha_nacimiento = $form['cliente']['fecha_nacimiento'];
-                $cliente->save();
+                $cliente = DB::transaction(function () use ($validated, $form, $garantiaFiles) {
+                    $cliente = Cliente::lockForUpdate()->findOrFail($validated['cliente_id']);
+                    $cliente->fecha_nacimiento = $form['cliente']['fecha_nacimiento'];
+                    $cliente->horario_de_pago = $form['cliente']['horario_de_pago'];
+                    $cliente->save();
 
                 $credito = Credito::firstOrNew(['cliente_id' => $cliente->id]);
                 $credito->monto_total = (float) $form['credito']['monto_total'];

--- a/app/Http/Controllers/PromotorController.php
+++ b/app/Http/Controllers/PromotorController.php
@@ -226,6 +226,7 @@ class PromotorController extends Controller
                 'apellido_m' => 'nullable|string|max:100',
                 'CURP' => 'required|string|size:18',
                 'monto' => 'required|numeric|min:0|max:3000',
+                'horario_de_pago' => 'required|date_format:H:i',
                 'aval_nombre' => 'required|string|max:100',
                 'aval_apellido_p' => 'required|string|max:100',
                 'aval_apellido_m' => 'nullable|string|max:100',
@@ -271,6 +272,7 @@ class PromotorController extends Controller
                     'tiene_credito_activo' => false,
                     'cartera_estado' => 'inactivo',
                     'monto_maximo' => $data['monto'],
+                    'horario_de_pago' => $data['horario_de_pago'],
                     'activo' => false,
                 ]);
 

--- a/app/Http/Controllers/SupervisorController.php
+++ b/app/Http/Controllers/SupervisorController.php
@@ -1006,7 +1006,7 @@ class SupervisorController extends Controller
                 $query->select('id', 'supervisor_id', 'nombre', 'apellido_p', 'apellido_m', 'venta_maxima', 'venta_proyectada_objetivo', 'dias_de_pago')
                     ->with([
                         'clientes' => function ($clienteQuery) {
-                            $clienteQuery->select('id', 'promotor_id', 'CURP', 'nombre', 'apellido_p', 'apellido_m', 'cartera_estado', 'fecha_nacimiento', 'tiene_credito_activo', 'monto_maximo', 'activo')
+                            $clienteQuery->select('id', 'promotor_id', 'CURP', 'nombre', 'apellido_p', 'apellido_m', 'cartera_estado', 'fecha_nacimiento', 'tiene_credito_activo', 'monto_maximo', 'horario_de_pago', 'activo')
                                 ->with([
                                     'documentos',
                                     'credito' => function ($creditoQuery) {
@@ -1209,7 +1209,7 @@ class SupervisorController extends Controller
             'promotores' => function ($query) {
                 $query->select('id', 'supervisor_id', 'nombre', 'apellido_p', 'apellido_m', 'venta_maxima', 'venta_proyectada_objetivo', 'dias_de_pago')
                     ->with(['clientes' => function ($clienteQuery) {
-                        $clienteQuery->select('id', 'promotor_id', 'nombre', 'apellido_p', 'apellido_m', 'cartera_estado', 'tiene_credito_activo')
+                        $clienteQuery->select('id', 'promotor_id', 'nombre', 'apellido_p', 'apellido_m', 'cartera_estado', 'tiene_credito_activo', 'horario_de_pago')
                             ->orderBy('nombre');
                     }])
                     ->orderBy('nombre');
@@ -1295,6 +1295,7 @@ class SupervisorController extends Controller
             'monto' => (float) ($cliente->monto_maximo ?? $credito?->monto_total ?? 0),
             'telefono' => $dato?->tel_cel ?? $dato?->tel_fijo,
             'direccion' => $direccion,
+            'horario_de_pago' => $cliente->horario_de_pago,
             'documentos' => [
                 'ine' => $ineDoc['url'] ?? null,
                 'comprobante' => $domDoc['url'] ?? null,

--- a/app/Models/Cliente.php
+++ b/app/Models/Cliente.php
@@ -23,6 +23,7 @@ class Cliente extends Model
         'tiene_credito_activo',
         'cartera_estado',
         'monto_maximo',
+        'horario_de_pago',
         'creado_en',
         'actualizado_en',
         'activo',
@@ -34,6 +35,7 @@ class Cliente extends Model
         'activo' => 'boolean',
         'creado_en' => 'datetime',
         'actualizado_en' => 'datetime',
+        'horario_de_pago' => 'string',
     ];
 
     public function promotor()

--- a/database/migrations/2025_08_03_022019_create_clientes_table.php
+++ b/database/migrations/2025_08_03_022019_create_clientes_table.php
@@ -19,6 +19,7 @@ class CreateClientesTable extends Migration
             $table->boolean('tiene_credito_activo');
             $table->string('cartera_estado', 100);
             $table->decimal('monto_maximo', 12, 2);
+            $table->string('horario_de_pago', 5);
             $table->timestamp('creado_en')->useCurrent();
             $table->timestamp('actualizado_en')->useCurrent()->useCurrentOnUpdate();
             $table->boolean('activo');

--- a/database/seeders/ClienteSeeder.php
+++ b/database/seeders/ClienteSeeder.php
@@ -76,6 +76,7 @@ class ClienteSeeder extends Seeder
                 'tiene_credito_activo' => $tieneCreditoActivo,
                 'cartera_estado' => $carteraEstado,
                 'monto_maximo' => $faker->randomElement(self::MONTO_OPCIONES),
+                'horario_de_pago' => sprintf('%02d:00', random_int(8, 18)),
                 'creado_en' => Carbon::now(),
                 'actualizado_en' => Carbon::now(),
                 'activo' => $tieneCreditoActivo,

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -222,6 +222,7 @@ class DatabaseSeeder extends Seeder
                 'tiene_credito_activo' => $tieneCreditoActivo,
                 'cartera_estado' => $carteraEstado,
                 'monto_maximo' => $faker->randomElement([3000, 4000, 5000, 5500, 6000, 6500, 7000, 7500, 8000, 10000, 12000, 15000, 20000]),
+                'horario_de_pago' => sprintf('%02d:00', random_int(8, 18)),
                 'creado_en' => Carbon::now(),
                 'actualizado_en' => Carbon::now(),
                 'activo' => $tieneCreditoActivo,

--- a/resources/views/mobile/ejecutivo/venta/clientes_prospectados.blade.php
+++ b/resources/views/mobile/ejecutivo/venta/clientes_prospectados.blade.php
@@ -106,6 +106,7 @@
             <p><span class="font-semibold">Estatus:</span> <span x-text="selected.cartera_estado || 'Sin definir'"></span></p>
             <p x-show="selected.fecha_nacimiento"><span class="font-semibold">Fecha nacimiento:</span> <span x-text="selected.fecha_nacimiento"></span></p>
             <p x-show="selected.telefono"><span class="font-semibold">Teléfono:</span> <span x-text="selected.telefono"></span></p>
+            <p x-show="selected.horario_de_pago"><span class="font-semibold">Horario de pago:</span> <span x-text="selected.horario_de_pago"></span></p>
             <p x-show="selected.direccion"><span class="font-semibold">Dirección:</span> <span x-text="selected.direccion"></span></p>
             <p x-show="selected.monto"><span class="font-semibold">Monto:</span> <span x-text="formatCurrency(selected.monto)"></span></p>
           </div>
@@ -278,6 +279,7 @@
             cartera_estado: '',
             fecha_nacimiento: '',
             telefono: '',
+            horario_de_pago: '',
             direccion: '',
             monto: null,
             monto_total: null,
@@ -298,6 +300,7 @@
               apellido_p: '',
               apellido_m: '',
               fecha_nacimiento: '',
+              horario_de_pago: '',
             },
             credito: {
               monto_total: '',
@@ -446,6 +449,7 @@
           form.cliente.apellido_p = apellidoP || '';
           form.cliente.apellido_m = apellidoM || '';
           form.cliente.fecha_nacimiento = this.selected.fecha_nacimiento || '';
+          form.cliente.horario_de_pago = this.selected.horario_de_pago || '';
 
           form.credito.monto_total = this.selected.monto_total ?? this.selected.monto ?? '';
           form.credito.periodicidad = normalize(this.selected.credito?.periodicidad) || '';

--- a/resources/views/mobile/ejecutivo/venta/clientes_supervisados.blade.php
+++ b/resources/views/mobile/ejecutivo/venta/clientes_supervisados.blade.php
@@ -111,6 +111,7 @@
 
           <div class="space-y-2 text-sm">
             <p x-show="selected.telefono"><span class="font-semibold">Telefono:</span> <span x-text="selected.telefono"></span></p>
+            <p x-show="selected.horario_de_pago"><span class="font-semibold">Horario de pago:</span> <span x-text="selected.horario_de_pago"></span></p>
             <p x-show="selected.direccion"><span class="font-semibold">Direccion:</span> <span x-text="selected.direccion"></span></p>
             <p x-show="selected.credito && selected.credito.estado"><span class="font-semibold">Estado del credito:</span> <span x-text="selected.credito.estado"></span></p>
             <p x-show="selected.credito && selected.credito.fecha_inicio"><span class="font-semibold">Fecha inicio credito:</span> <span x-text="selected.credito.fecha_inicio"></span></p>
@@ -224,6 +225,7 @@
             nombre: '',
             curp: '',
             telefono: '',
+            horario_de_pago: '',
             direccion: '',
             promotor: '',
             monto: null,

--- a/resources/views/mobile/ejecutivo/venta/nuevo-cliente/step-clientes.blade.php
+++ b/resources/views/mobile/ejecutivo/venta/nuevo-cliente/step-clientes.blade.php
@@ -40,5 +40,13 @@
              class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
              x-model="form.cliente.fecha_nacimiento" name="cliente[fecha_nacimiento]">
     </div>
+    <div class="space-y-1">
+      <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Horario de pago <span class="text-red-500">*</span></label>
+      <input type="time"
+             class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+             step="60"
+             required
+             x-model="form.cliente.horario_de_pago" name="cliente[horario_de_pago]">
+    </div>
   </div>
 </div>

--- a/resources/views/mobile/promotor/venta/ingresar_cliente.blade.php
+++ b/resources/views/mobile/promotor/venta/ingresar_cliente.blade.php
@@ -64,6 +64,7 @@
             f.nombre.value.trim() &&
             f.apellido_p.value.trim() &&
             f['CURP'].value.trim().length === 18 &&
+            f.horario_de_pago.value &&
             this.validateMonto(f.monto.value);
           if (!valido) {
             this.resultadoExito = false;

--- a/resources/views/mobile/promotor/venta/modal_nuevo_cliente.blade.php
+++ b/resources/views/mobile/promotor/venta/modal_nuevo_cliente.blade.php
@@ -22,6 +22,9 @@
         <p class="font-semibold mt-2">CURP:</p>
         <input name="CURP" type="text" placeholder="CURP" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-400">
 
+        <p class="font-semibold mt-2">Horario de pago:</p>
+        <input name="horario_de_pago" type="time" step="60" required class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-400">
+
         <p class="font-semibold mt-2">Monto del crédito:</p>
         <input name="monto" type="number" step="100.00" min="0" max="3000" placeholder="Monto" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-400">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">

--- a/resources/views/mobile/supervisor/venta/clientes_prospectados.blade.php
+++ b/resources/views/mobile/supervisor/venta/clientes_prospectados.blade.php
@@ -106,6 +106,7 @@
             <p><span class="font-semibold">Estatus:</span> <span x-text="selected.cartera_estado || 'Sin definir'"></span></p>
             <p x-show="selected.fecha_nacimiento"><span class="font-semibold">Fecha nacimiento:</span> <span x-text="selected.fecha_nacimiento"></span></p>
             <p x-show="selected.telefono"><span class="font-semibold">Teléfono:</span> <span x-text="selected.telefono"></span></p>
+            <p x-show="selected.horario_de_pago"><span class="font-semibold">Horario de pago:</span> <span x-text="selected.horario_de_pago"></span></p>
             <p x-show="selected.direccion"><span class="font-semibold">Dirección:</span> <span x-text="selected.direccion"></span></p>
             <p x-show="selected.monto"><span class="font-semibold">Monto:</span> <span x-text="formatCurrency(selected.monto)"></span></p>
           </div>
@@ -278,6 +279,7 @@
             cartera_estado: '',
             fecha_nacimiento: '',
             telefono: '',
+            horario_de_pago: '',
             direccion: '',
             monto: null,
             monto_total: null,
@@ -298,6 +300,7 @@
               apellido_p: '',
               apellido_m: '',
               fecha_nacimiento: '',
+              horario_de_pago: '',
             },
             credito: {
               monto_total: '',
@@ -446,6 +449,7 @@
           form.cliente.apellido_p = apellidoP || '';
           form.cliente.apellido_m = apellidoM || '';
           form.cliente.fecha_nacimiento = this.selected.fecha_nacimiento || '';
+          form.cliente.horario_de_pago = this.selected.horario_de_pago || '';
 
           form.credito.monto_total = this.selected.monto_total ?? this.selected.monto ?? '';
           form.credito.periodicidad = normalize(this.selected.credito?.periodicidad) || '';

--- a/resources/views/mobile/supervisor/venta/clientes_supervisados.blade.php
+++ b/resources/views/mobile/supervisor/venta/clientes_supervisados.blade.php
@@ -111,6 +111,7 @@
 
           <div class="space-y-2 text-sm">
             <p x-show="selected.telefono"><span class="font-semibold">Telefono:</span> <span x-text="selected.telefono"></span></p>
+            <p x-show="selected.horario_de_pago"><span class="font-semibold">Horario de pago:</span> <span x-text="selected.horario_de_pago"></span></p>
             <p x-show="selected.direccion"><span class="font-semibold">Direccion:</span> <span x-text="selected.direccion"></span></p>
             <p x-show="selected.credito && selected.credito.estado"><span class="font-semibold">Estado del credito:</span> <span x-text="selected.credito.estado"></span></p>
             <p x-show="selected.credito && selected.credito.fecha_inicio"><span class="font-semibold">Fecha inicio credito:</span> <span x-text="selected.credito.fecha_inicio"></span></p>
@@ -224,6 +225,7 @@
             nombre: '',
             curp: '',
             telefono: '',
+            horario_de_pago: '',
             direccion: '',
             promotor: '',
             monto: null,

--- a/resources/views/mobile/supervisor/venta/nuevo-cliente/step-clientes.blade.php
+++ b/resources/views/mobile/supervisor/venta/nuevo-cliente/step-clientes.blade.php
@@ -40,5 +40,13 @@
              class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
              x-model="form.cliente.fecha_nacimiento" name="cliente[fecha_nacimiento]">
     </div>
+    <div class="space-y-1">
+      <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Horario de pago <span class="text-red-500">*</span></label>
+      <input type="time"
+             class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+             step="60"
+             required
+             x-model="form.cliente.horario_de_pago" name="cliente[horario_de_pago]">
+    </div>
   </div>
 </div>

--- a/resources/views/mobile_legacy/ejecutivo/venta/clientes_prospectados.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/venta/clientes_prospectados.blade.php
@@ -106,6 +106,7 @@
             <p><span class="font-semibold">Estatus:</span> <span x-text="selected.cartera_estado || 'Sin definir'"></span></p>
             <p x-show="selected.fecha_nacimiento"><span class="font-semibold">Fecha nacimiento:</span> <span x-text="selected.fecha_nacimiento"></span></p>
             <p x-show="selected.telefono"><span class="font-semibold">Teléfono:</span> <span x-text="selected.telefono"></span></p>
+            <p x-show="selected.horario_de_pago"><span class="font-semibold">Horario de pago:</span> <span x-text="selected.horario_de_pago"></span></p>
             <p x-show="selected.direccion"><span class="font-semibold">Dirección:</span> <span x-text="selected.direccion"></span></p>
             <p x-show="selected.monto"><span class="font-semibold">Monto:</span> <span x-text="formatCurrency(selected.monto)"></span></p>
           </div>
@@ -278,6 +279,7 @@
             cartera_estado: '',
             fecha_nacimiento: '',
             telefono: '',
+            horario_de_pago: '',
             direccion: '',
             monto: null,
             monto_total: null,
@@ -298,6 +300,7 @@
               apellido_p: '',
               apellido_m: '',
               fecha_nacimiento: '',
+              horario_de_pago: '',
             },
             credito: {
               monto_total: '',
@@ -446,6 +449,7 @@
           form.cliente.apellido_p = apellidoP || '';
           form.cliente.apellido_m = apellidoM || '';
           form.cliente.fecha_nacimiento = this.selected.fecha_nacimiento || '';
+          form.cliente.horario_de_pago = this.selected.horario_de_pago || '';
 
           form.credito.monto_total = this.selected.monto_total ?? this.selected.monto ?? '';
           form.credito.periodicidad = normalize(this.selected.credito?.periodicidad) || '';

--- a/resources/views/mobile_legacy/ejecutivo/venta/clientes_supervisados.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/venta/clientes_supervisados.blade.php
@@ -111,6 +111,7 @@
 
           <div class="space-y-2 text-sm">
             <p x-show="selected.telefono"><span class="font-semibold">Telefono:</span> <span x-text="selected.telefono"></span></p>
+            <p x-show="selected.horario_de_pago"><span class="font-semibold">Horario de pago:</span> <span x-text="selected.horario_de_pago"></span></p>
             <p x-show="selected.direccion"><span class="font-semibold">Direccion:</span> <span x-text="selected.direccion"></span></p>
             <p x-show="selected.credito && selected.credito.estado"><span class="font-semibold">Estado del credito:</span> <span x-text="selected.credito.estado"></span></p>
             <p x-show="selected.credito && selected.credito.fecha_inicio"><span class="font-semibold">Fecha inicio credito:</span> <span x-text="selected.credito.fecha_inicio"></span></p>
@@ -224,6 +225,7 @@
             nombre: '',
             curp: '',
             telefono: '',
+            horario_de_pago: '',
             direccion: '',
             promotor: '',
             monto: null,

--- a/resources/views/mobile_legacy/ejecutivo/venta/nuevo-cliente/step-clientes.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/venta/nuevo-cliente/step-clientes.blade.php
@@ -40,5 +40,13 @@
              class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
              x-model="form.cliente.fecha_nacimiento" name="cliente[fecha_nacimiento]">
     </div>
+    <div class="space-y-1">
+      <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Horario de pago <span class="text-red-500">*</span></label>
+      <input type="time"
+             class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+             step="60"
+             required
+             x-model="form.cliente.horario_de_pago" name="cliente[horario_de_pago]">
+    </div>
   </div>
 </div>

--- a/resources/views/mobile_legacy/promotor/venta/ingresar_cliente.blade.php
+++ b/resources/views/mobile_legacy/promotor/venta/ingresar_cliente.blade.php
@@ -64,6 +64,7 @@
             f.nombre.value.trim() &&
             f.apellido_p.value.trim() &&
             f['CURP'].value.trim().length === 18 &&
+            f.horario_de_pago.value &&
             this.validateMonto(f.monto.value);
           if (!valido) {
             this.resultadoExito = false;

--- a/resources/views/mobile_legacy/promotor/venta/modal_nuevo_cliente.blade.php
+++ b/resources/views/mobile_legacy/promotor/venta/modal_nuevo_cliente.blade.php
@@ -22,6 +22,9 @@
         <p class="font-semibold mt-2">CURP:</p>
         <input name="CURP" type="text" placeholder="CURP" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-400">
 
+        <p class="font-semibold mt-2">Horario de pago:</p>
+        <input name="horario_de_pago" type="time" step="60" required class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-400">
+
         <p class="font-semibold mt-2">Monto del crédito:</p>
         <input name="monto" type="number" step="100.00" min="0" max="3000" placeholder="Monto" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-400">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">

--- a/resources/views/mobile_legacy/supervisor/venta/clientes_prospectados.blade.php
+++ b/resources/views/mobile_legacy/supervisor/venta/clientes_prospectados.blade.php
@@ -106,6 +106,7 @@
             <p><span class="font-semibold">Estatus:</span> <span x-text="selected.cartera_estado || 'Sin definir'"></span></p>
             <p x-show="selected.fecha_nacimiento"><span class="font-semibold">Fecha nacimiento:</span> <span x-text="selected.fecha_nacimiento"></span></p>
             <p x-show="selected.telefono"><span class="font-semibold">Teléfono:</span> <span x-text="selected.telefono"></span></p>
+            <p x-show="selected.horario_de_pago"><span class="font-semibold">Horario de pago:</span> <span x-text="selected.horario_de_pago"></span></p>
             <p x-show="selected.direccion"><span class="font-semibold">Dirección:</span> <span x-text="selected.direccion"></span></p>
             <p x-show="selected.monto"><span class="font-semibold">Monto:</span> <span x-text="formatCurrency(selected.monto)"></span></p>
           </div>
@@ -278,6 +279,7 @@
             cartera_estado: '',
             fecha_nacimiento: '',
             telefono: '',
+            horario_de_pago: '',
             direccion: '',
             monto: null,
             monto_total: null,
@@ -298,6 +300,7 @@
               apellido_p: '',
               apellido_m: '',
               fecha_nacimiento: '',
+              horario_de_pago: '',
             },
             credito: {
               monto_total: '',
@@ -446,6 +449,7 @@
           form.cliente.apellido_p = apellidoP || '';
           form.cliente.apellido_m = apellidoM || '';
           form.cliente.fecha_nacimiento = this.selected.fecha_nacimiento || '';
+          form.cliente.horario_de_pago = this.selected.horario_de_pago || '';
 
           form.credito.monto_total = this.selected.monto_total ?? this.selected.monto ?? '';
           form.credito.periodicidad = normalize(this.selected.credito?.periodicidad) || '';

--- a/resources/views/mobile_legacy/supervisor/venta/clientes_supervisados.blade.php
+++ b/resources/views/mobile_legacy/supervisor/venta/clientes_supervisados.blade.php
@@ -111,6 +111,7 @@
 
           <div class="space-y-2 text-sm">
             <p x-show="selected.telefono"><span class="font-semibold">Telefono:</span> <span x-text="selected.telefono"></span></p>
+            <p x-show="selected.horario_de_pago"><span class="font-semibold">Horario de pago:</span> <span x-text="selected.horario_de_pago"></span></p>
             <p x-show="selected.direccion"><span class="font-semibold">Direccion:</span> <span x-text="selected.direccion"></span></p>
             <p x-show="selected.credito && selected.credito.estado"><span class="font-semibold">Estado del credito:</span> <span x-text="selected.credito.estado"></span></p>
             <p x-show="selected.credito && selected.credito.fecha_inicio"><span class="font-semibold">Fecha inicio credito:</span> <span x-text="selected.credito.fecha_inicio"></span></p>
@@ -224,6 +225,7 @@
             nombre: '',
             curp: '',
             telefono: '',
+            horario_de_pago: '',
             direccion: '',
             promotor: '',
             monto: null,

--- a/resources/views/mobile_legacy/supervisor/venta/nuevo-cliente/step-clientes.blade.php
+++ b/resources/views/mobile_legacy/supervisor/venta/nuevo-cliente/step-clientes.blade.php
@@ -40,5 +40,13 @@
              class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
              x-model="form.cliente.fecha_nacimiento" name="cliente[fecha_nacimiento]">
     </div>
+    <div class="space-y-1">
+      <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Horario de pago <span class="text-red-500">*</span></label>
+      <input type="time"
+             class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+             step="60"
+             required
+             x-model="form.cliente.horario_de_pago" name="cliente[horario_de_pago]">
+    </div>
   </div>
 </div>

--- a/tests/Feature/PromotorObjetivoTest.php
+++ b/tests/Feature/PromotorObjetivoTest.php
@@ -154,6 +154,7 @@ function createClienteParaPromotor(Promotor $promotor, string $curp, string $nom
         'tiene_credito_activo' => true,
         'cartera_estado' => 'activo',
         'monto_maximo' => 15000,
+        'horario_de_pago' => '10:00',
         'creado_en' => now(),
         'actualizado_en' => now(),
         'activo' => true,


### PR DESCRIPTION
## Summary
- add the horario_de_pago column to clientes and expose it through the Cliente model
- require horario_de_pago across controllers, seeders, and tests so new and existing clients persist their payment time
- update mobile and legacy client capture and detail views to collect and display the payment schedule

## Testing
- `php artisan test` *(fails: database migrations for the kanban connection already exist in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d307cded08832581f677e026faa250