### PR TITLE
Expose promotor payment days throughout app

### DIFF
--- a/app/Http/Controllers/SupervisorController.php
+++ b/app/Http/Controllers/SupervisorController.php
@@ -711,7 +711,7 @@ class SupervisorController extends Controller
         }
 
         $promotoresPaginator = Promotor::where('supervisor_id', $supervisor->id)
-            ->select('id', 'nombre', 'apellido_p', 'apellido_m')
+            ->select('id', 'nombre', 'apellido_p', 'apellido_m', 'dias_de_pago')
             ->orderBy('nombre')
             ->paginate(5);
 
@@ -765,9 +765,10 @@ class SupervisorController extends Controller
             })->filter()->values();
 
             return [
-                'nombre'   => trim($p->nombre . ' ' . $p->apellido_p . ' ' . ($p->apellido_m ?? '')),
-                'dinero'   => $dinero,
-                'clientes' => $items,
+                'nombre'       => trim($p->nombre . ' ' . $p->apellido_p . ' ' . ($p->apellido_m ?? '')),
+                'dias_de_pago' => trim((string) ($p->dias_de_pago ?? '')),
+                'dinero'       => $dinero,
+                'clientes'     => $items,
             ];
         });
 
@@ -791,7 +792,7 @@ class SupervisorController extends Controller
         }
 
         $promotoresPaginator = Promotor::where('supervisor_id', $supervisor->id)
-            ->select('id', 'nombre', 'apellido_p', 'apellido_m')
+            ->select('id', 'nombre', 'apellido_p', 'apellido_m', 'dias_de_pago')
             ->orderBy('nombre')
             ->paginate(5);
 
@@ -833,10 +834,11 @@ class SupervisorController extends Controller
             $porcentajeVencido = $baseCreditos > 0 ? round(($dineroVencido / $baseCreditos) * 100) : 0;
 
             return [
-                'nombre'   => trim($p->nombre . ' ' . $p->apellido_p . ' ' . ($p->apellido_m ?? '')),
-                'dinero'   => $dineroVencido,
-                'vencido'  => $porcentajeVencido,
-                'clientes' => $items->values(),
+                'nombre'       => trim($p->nombre . ' ' . $p->apellido_p . ' ' . ($p->apellido_m ?? '')),
+                'dias_de_pago' => trim((string) ($p->dias_de_pago ?? '')),
+                'dinero'       => $dineroVencido,
+                'vencido'      => $porcentajeVencido,
+                'clientes'     => $items->values(),
             ];
         });
 
@@ -860,7 +862,7 @@ class SupervisorController extends Controller
         }
 
         $promotoresPaginator = Promotor::where('supervisor_id', $supervisor->id)
-            ->select('id', 'nombre', 'apellido_p', 'apellido_m')
+            ->select('id', 'nombre', 'apellido_p', 'apellido_m', 'dias_de_pago')
             ->orderBy('nombre')
             ->paginate(5);
 
@@ -900,8 +902,9 @@ class SupervisorController extends Controller
             })->values();
 
             return [
-                'nombre'   => trim($p->nombre . ' ' . $p->apellido_p . ' ' . ($p->apellido_m ?? '')),
-                'clientes' => $items,
+                'nombre'       => trim($p->nombre . ' ' . $p->apellido_p . ' ' . ($p->apellido_m ?? '')),
+                'dias_de_pago' => trim((string) ($p->dias_de_pago ?? '')),
+                'clientes'     => $items,
             ];
         });
 
@@ -925,7 +928,7 @@ class SupervisorController extends Controller
         }
 
         $promotoresPaginator = Promotor::where('supervisor_id', $supervisor->id)
-            ->select('id', 'nombre', 'apellido_p', 'apellido_m')
+            ->select('id', 'nombre', 'apellido_p', 'apellido_m', 'dias_de_pago')
             ->orderBy('nombre')
             ->paginate(5);
 
@@ -966,10 +969,11 @@ class SupervisorController extends Controller
             $porcentajeFalla = $baseCreditos > 0 ? round(($dineroFalla / $baseCreditos) * 100) : 0;
 
             return [
-                'nombre'   => trim($p->nombre . ' ' . $p->apellido_p . ' ' . ($p->apellido_m ?? '')),
-                'dinero'   => $dineroFalla,
-                'falla'    => $porcentajeFalla,
-                'clientes' => $items->values(),
+                'nombre'       => trim($p->nombre . ' ' . $p->apellido_p . ' ' . ($p->apellido_m ?? '')),
+                'dias_de_pago' => trim((string) ($p->dias_de_pago ?? '')),
+                'dinero'       => $dineroFalla,
+                'falla'        => $porcentajeFalla,
+                'clientes'     => $items->values(),
             ];
         });
 

--- a/app/Models/Promotor.php
+++ b/app/Models/Promotor.php
@@ -11,6 +11,9 @@ class Promotor extends Model
     const CREATED_AT = 'creado_en';
     const UPDATED_AT = 'actualizado_en';
     protected $table = 'promotores';
+    protected $casts = [
+        'dias_de_pago' => 'string',
+    ];
 
     public function user()
     {

--- a/database/migrations/2025_08_03_021957_create_promotores_table.php
+++ b/database/migrations/2025_08_03_021957_create_promotores_table.php
@@ -20,7 +20,9 @@ class CreatePromotoresTable extends Migration
             $table->string('colonia', 100);
             $table->decimal('venta_proyectada_objetivo', 12, 2);
             $table->decimal('bono', 12, 2);
-            $table->string('dias_de_pago', 100)->nullable();
+            $table->string('dias_de_pago', 100)
+                  ->nullable()
+                  ->comment('Días en los que el promotor realiza cobros programados');
             $table->timestamp('creado_en')->useCurrent();
             $table->timestamp('actualizado_en')->useCurrent()->useCurrentOnUpdate();
 

--- a/resources/views/mobile/ejecutivo/cartera/cartera_activa.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_activa.blade.php
@@ -37,9 +37,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-indigo-100 text-indigo-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div class="flex flex-col">
                             <span class="text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile/ejecutivo/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_falla.blade.php
@@ -14,9 +14,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-red-100 text-red-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile/ejecutivo/cartera/cartera_inactiva.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_inactiva.blade.php
@@ -12,9 +12,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-gray-200 text-gray-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                 </div>

--- a/resources/views/mobile/ejecutivo/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_vencida.blade.php
@@ -16,9 +16,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-orange-100 text-orange-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile/supervisor/Apertura/apertura.blade.php
+++ b/resources/views/mobile/supervisor/Apertura/apertura.blade.php
@@ -1,12 +1,21 @@
 {{-- resources/views/mobile/supervisor/Apertura/apertura.blade.php --}}
 <x-layouts.mobile.mobile-layout title="Alta de Promotor">
-@php($faker = \Faker\Factory::create('es_MX'))
+@php
+    $faker = \Faker\Factory::create('es_MX');
+    $diasPagoEjemplo = $faker->randomElement([
+        'lunes, miércoles',
+        'martes, jueves',
+        'viernes',
+        'lunes a viernes',
+    ]);
+@endphp
     <div
         x-data="{
             nombre: '',
             domicilio: '',
             telefono: '',
             correo: '',
+            diasPago: @json($diasPagoEjemplo),
             ineUploaded: false,
             compUploaded: false,
             submit() {
@@ -36,6 +45,7 @@
                 this.domicilio = '';
                 this.telefono = '';
                 this.correo = '';
+                this.diasPago = '';
                 this.ineUploaded = false;
                 this.compUploaded = false;
             }
@@ -82,6 +92,17 @@
                     x-model="correo"
                     class="mt-1 w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
                 />
+            </div>
+
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Días de pago</label>
+                <input
+                    type="text"
+                    x-model="diasPago"
+                    placeholder="Ej. lunes, miércoles"
+                    class="mt-1 w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                />
+                <p class="mt-1 text-xs text-gray-500">Indica los días habituales de cobro separados por comas.</p>
             </div>
 
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/resources/views/mobile/supervisor/cartera/cartera.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera.blade.php
@@ -62,9 +62,15 @@
                   <span class="inline-flex items-center justify-center w-6 h-6 text-[11px] font-bold rounded-full bg-indigo-100 text-indigo-700">
                     {{ $loop->iteration }}
                   </span>
-                  <span class="text-sm font-semibold text-gray-900">
-                    {{ $p->nombre }} {{ $p->apellido_p }} {{ $p->apellido_m }}
-                  </span>
+                  <div class="flex flex-col">
+                    <span class="text-sm font-semibold text-gray-900">
+                      {{ $p->nombre }} {{ $p->apellido_p }} {{ $p->apellido_m }}
+                    </span>
+                    @php $diasPago = trim((string) ($p->dias_de_pago ?? '')); @endphp
+                    @if($diasPago !== '')
+                      <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                    @endif
+                  </div>
                 </div>
               </div>
               {{-- Si luego quieres barra de progreso por promotor, calcúlala en el controlador y expón $p->progress --}}

--- a/resources/views/mobile/supervisor/cartera/cartera_activa.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_activa.blade.php
@@ -37,9 +37,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-indigo-100 text-indigo-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div class="flex flex-col">
                             <span class="text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile/supervisor/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_falla.blade.php
@@ -14,9 +14,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-red-100 text-red-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile/supervisor/cartera/cartera_inactiva.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_inactiva.blade.php
@@ -12,9 +12,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-gray-200 text-gray-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                 </div>

--- a/resources/views/mobile/supervisor/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_vencida.blade.php
@@ -16,9 +16,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-orange-100 text-orange-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile/supervisor/cartera/promotor.blade.php
+++ b/resources/views/mobile/supervisor/cartera/promotor.blade.php
@@ -3,6 +3,10 @@
     <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
       <div class="p-5">
         <h2 class="text-base font-bold text-gray-900 mb-3">{{ $promotor->nombre }} {{ $promotor->apellido_p }} {{ $promotor->apellido_m }}</h2>
+        @php $diasPago = trim((string) ($promotor->dias_de_pago ?? '')); @endphp
+        @if($diasPago !== '')
+          <p class="text-xs text-gray-500 mb-4">Días de pago: {{ $diasPago }}</p>
+        @endif
         <div class="space-y-3">
           @forelse($clientes as $c)
             <a href="{{ route('mobile.supervisor.cliente_historial', array_merge($supervisorContextQuery ?? [], ['cliente' => $c->id])) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">

--- a/resources/views/mobile_legacy/ejecutivo/cartera/cartera_activa.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/cartera/cartera_activa.blade.php
@@ -37,9 +37,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-indigo-100 text-indigo-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div class="flex flex-col">
                             <span class="text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile_legacy/ejecutivo/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/cartera/cartera_falla.blade.php
@@ -14,9 +14,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-red-100 text-red-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile_legacy/ejecutivo/cartera/cartera_inactiva.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/cartera/cartera_inactiva.blade.php
@@ -12,9 +12,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-gray-200 text-gray-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                 </div>

--- a/resources/views/mobile_legacy/ejecutivo/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/cartera/cartera_vencida.blade.php
@@ -16,9 +16,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-orange-100 text-orange-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile_legacy/ejecutivo/cartera/promotor.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/cartera/promotor.blade.php
@@ -3,6 +3,10 @@
     <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
       <div class="p-5">
         <h2 class="text-base font-bold text-gray-900 mb-3">{{ $promotor->nombre }} {{ $promotor->apellido_p }} {{ $promotor->apellido_m }}</h2>
+        @php $diasPago = trim((string) ($promotor->dias_de_pago ?? '')); @endphp
+        @if($diasPago !== '')
+          <p class="text-xs text-gray-500 mb-4">Días de pago: {{ $diasPago }}</p>
+        @endif
         <div class="space-y-3">
           @forelse($clientes as $c)
             <a href="{{ route('mobile.supervisor.cliente_historial', $c->id) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">

--- a/resources/views/mobile_legacy/supervisor/Apertura/apertura.blade.php
+++ b/resources/views/mobile_legacy/supervisor/Apertura/apertura.blade.php
@@ -1,12 +1,21 @@
 {{-- resources/views/mobile/supervisor/Apertura/apertura.blade.php --}}
 <x-layouts.mobile.mobile-layout title="Alta de Promotor">
-@php($faker = \Faker\Factory::create('es_MX'))
+@php
+    $faker = \Faker\Factory::create('es_MX');
+    $diasPagoEjemplo = $faker->randomElement([
+        'lunes, miércoles',
+        'martes, jueves',
+        'viernes',
+        'lunes a viernes',
+    ]);
+@endphp
     <div
         x-data="{
             nombre: '',
             domicilio: '',
             telefono: '',
             correo: '',
+            diasPago: @json($diasPagoEjemplo),
             ineUploaded: false,
             compUploaded: false,
             submit() {
@@ -36,6 +45,7 @@
                 this.domicilio = '';
                 this.telefono = '';
                 this.correo = '';
+                this.diasPago = '';
                 this.ineUploaded = false;
                 this.compUploaded = false;
             }
@@ -82,6 +92,17 @@
                     x-model="correo"
                     class="mt-1 w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
                 />
+            </div>
+
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Días de pago</label>
+                <input
+                    type="text"
+                    x-model="diasPago"
+                    placeholder="Ej. lunes, miércoles"
+                    class="mt-1 w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                />
+                <p class="mt-1 text-xs text-gray-500">Indica los días habituales de cobro separados por comas.</p>
             </div>
 
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera.blade.php
@@ -62,9 +62,15 @@
                   <span class="inline-flex items-center justify-center w-6 h-6 text-[11px] font-bold rounded-full bg-indigo-100 text-indigo-700">
                     {{ $loop->iteration }}
                   </span>
-                  <span class="text-sm font-semibold text-gray-900">
-                    {{ $p->nombre }} {{ $p->apellido_p }} {{ $p->apellido_m }}
-                  </span>
+                  <div class="flex flex-col">
+                    <span class="text-sm font-semibold text-gray-900">
+                      {{ $p->nombre }} {{ $p->apellido_p }} {{ $p->apellido_m }}
+                    </span>
+                    @php $diasPago = trim((string) ($p->dias_de_pago ?? '')); @endphp
+                    @if($diasPago !== '')
+                      <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                    @endif
+                  </div>
                 </div>
               </div>
               {{-- Si luego quieres barra de progreso por promotor, calcúlala en el controlador y expón $p->progress --}}

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera_activa.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera_activa.blade.php
@@ -37,9 +37,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-indigo-100 text-indigo-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div class="flex flex-col">
                             <span class="text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera_falla.blade.php
@@ -14,9 +14,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-red-100 text-red-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera_inactiva.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera_inactiva.blade.php
@@ -12,9 +12,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-gray-200 text-gray-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                 </div>

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera_vencida.blade.php
@@ -16,9 +16,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-orange-100 text-orange-700">
                             {{ $loop->iteration }}
                         </span>
+                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
+                            @if($diasPago !== '')
+                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile_legacy/supervisor/cartera/promotor.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/promotor.blade.php
@@ -3,6 +3,10 @@
     <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
       <div class="p-5">
         <h2 class="text-base font-bold text-gray-900 mb-3">{{ $promotor->nombre }} {{ $promotor->apellido_p }} {{ $promotor->apellido_m }}</h2>
+        @php $diasPago = trim((string) ($promotor->dias_de_pago ?? '')); @endphp
+        @if($diasPago !== '')
+          <p class="text-xs text-gray-500 mb-4">Días de pago: {{ $diasPago }}</p>
+        @endif
         <div class="space-y-3">
           @forelse($clientes as $c)
             <a href="{{ route('mobile.supervisor.cliente_historial', $c->id) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">


### PR DESCRIPTION
## Summary
- document the `dias_de_pago` column in the promotores migration and cast it on the model
- include the new field in supervisor portfolio queries so the data is available to mobile views
- surface capture and display of payment days across supervisor and ejecutivo mobile (legacy and current) screens

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d36a828d588325870e97e2940acc36