### PR TITLE
Add reload and return controls to supervisor prospects view

### DIFF
--- a/resources/views/mobile/supervisor/venta/clientes_prospectados.blade.php
+++ b/resources/views/mobile/supervisor/venta/clientes_prospectados.blade.php
@@ -237,12 +237,16 @@
       </div>
     </template>
 
+    @php
+      $contextQuery = $supervisorContextQuery ?? [];
+    @endphp
+
     <div class="space-y-3">
-      <a href="{{ route('mobile.supervisor.clientes_prospectados', array_merge($supervisorContextQuery ?? [], [])) }}"
+      <a href="{{ route('mobile.supervisor.clientes_prospectados', $contextQuery) }}"
          class="block text-center py-3 rounded-2xl bg-gradient-to-r from-blue-600 to-blue-500 text-white font-semibold shadow-lg hover:from-blue-700 hover:to-blue-600 transition">
         Recargar
       </a>
-      <a href="{{ route('mobile.supervisor.venta', array_merge($supervisorContextQuery ?? [], [])) }}"
+      <a href="{{ route('mobile.supervisor.venta', $contextQuery) }}"
          class="block text-center py-3 rounded-2xl bg-gradient-to-r from-blue-600 to-blue-500 text-white font-semibold shadow-lg hover:from-blue-700 hover:to-blue-600 transition">
         Regresar a Venta
       </a>

--- a/tests/Feature/SupervisorClientesProspectadosTest.php
+++ b/tests/Feature/SupervisorClientesProspectadosTest.php
@@ -15,14 +15,20 @@ beforeEach(function () {
 it('muestra los botones de recargar y regreso en clientes prospectados', function () {
     [$user, $supervisor] = createSupervisorClienteProspectadoContext();
 
+    $contextQuery = ['supervisor' => $supervisor->id];
+    $reloadRoute = route('mobile.supervisor.clientes_prospectados', $contextQuery);
+    $ventaRoute = route('mobile.supervisor.venta', $contextQuery);
+
     $response = $this->actingAs($user)->get(route('mobile.supervisor.clientes_prospectados'));
 
     $response
         ->assertOk()
         ->assertSeeText('Recargar')
-        ->assertSee(route('mobile.supervisor.clientes_prospectados', ['supervisor' => $supervisor->id]), false)
+        ->assertSee('href="' . $reloadRoute . '"', false)
         ->assertSeeText('Regresar a Venta')
-        ->assertSee(route('mobile.supervisor.venta', ['supervisor' => $supervisor->id]), false);
+        ->assertSee('href="' . $ventaRoute . '"', false);
+
+    expect(substr_count($response->getContent(), 'bg-gradient-to-r from-blue-600 to-blue-500'))->toBeGreaterThanOrEqual(2);
 });
 
 /**


### PR DESCRIPTION
## Summary
- render gradient reload and return buttons in the supervisor prospect listing using the shared context query
- extend the feature test to assert the presence and styling of both navigation buttons

## Testing
- KANBAN_DB_DATABASE=':memory:' php artisan test tests/Feature/SupervisorClientesProspectadosTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d36f6524d8832585957a181294384d