### PR TITLE
Fix supervisor mobile route links

### DIFF
--- a/resources/views/mobile/supervisor/venta/clientes_prospectados.blade.php
+++ b/resources/views/mobile/supervisor/venta/clientes_prospectados.blade.php
@@ -8,6 +8,10 @@
 @endphp
 
 <x-layouts.mobile.mobile-layout title="Clientes Prospectados">
+  @php
+      $contextQuery = $supervisorContextQuery ?? [];
+  @endphp
+
   <div x-data="clientesProspectados()" x-init="init()" class="p-4 w-full max-w-md mx-auto space-y-6">
     @forelse($promotores as $promotor)
       <div class="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden">
@@ -196,13 +200,13 @@
 
      {{-- ===================== Navegación ===================== --}}
     <section class="grid grid-cols-3 gap-3">
-      <a href="{{ url()->previous() }}" class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
+      <a href="{{ route('mobile.supervisor.venta', $contextQuery) }}" class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
         Regresar
       </a>
-      <a href="{{ url()->current() }}" class="inline-flex items-center justify-center rounded-xl bg-blue-600 text-white text-sm font-semibold px-3 py-2 hover:bg-blue-700 shadow">
+      <a href="{{ route('mobile.supervisor.clientes_prospectados', $contextQuery) }}" class="inline-flex items-center justify-center rounded-xl bg-blue-600 text-white text-sm font-semibold px-3 py-2 hover:bg-blue-700 shadow">
         Actualizar
       </a>
-      <a href="{{ route('mobile.supervisor.reporte') }}" class="inline-flex items-center justify-center rounded-xl bg-indigo-600 text-white text-sm font-semibold px-3 py-2 hover:bg-indigo-700 shadow">
+      <a href="{{ route('mobile.supervisor.reporte', $contextQuery) }}" class="inline-flex items-center justify-center rounded-xl bg-indigo-600 text-white text-sm font-semibold px-3 py-2 hover:bg-indigo-700 shadow">
         Reporte
       </a>
     </section>

--- a/resources/views/mobile/supervisor/venta/clientes_supervisados.blade.php
+++ b/resources/views/mobile/supervisor/venta/clientes_supervisados.blade.php
@@ -243,11 +243,11 @@
     @endphp
 
     <div class="space-y-3">
-      <a href="{{ url()->current() }}"
+      <a href="{{ route('mobile.supervisor.clientes_supervisados', $contextQuery) }}"
          class="block text-center py-3 rounded-2xl bg-gradient-to-r from-blue-600 to-blue-500 text-white font-semibold shadow-lg hover:from-blue-700 hover:to-blue-600 transition">
         Recargar
       </a>
-      <a href="{{ url()->previous() }}"
+      <a href="{{ route('mobile.supervisor.venta', $contextQuery) }}"
          class="block text-center py-3 rounded-2xl bg-gradient-to-r from-blue-600 to-blue-500 text-white font-semibold shadow-lg hover:from-blue-700 hover:to-blue-600 transition">
         Regresar a Venta
       </a>
@@ -274,8 +274,8 @@
         saving: false,
         actionInProgress: null,
         maxGarantias: 8,
-        postUrl: '{{ route('mobile.supervisor.nuevo_cliente.store') }}',
-        registrarCreditoUrlTemplate: @js(route('mobile.supervisor.clientes_supervisados.registrar_credito', ['cliente' => '__CLIENTE_ID__'])),
+        postUrl: '{{ route('mobile.supervisor.nuevo_cliente.store', $contextQuery) }}',
+        registrarCreditoUrlTemplate: @js(route('mobile.supervisor.clientes_prospectados.registrar_credito', array_merge($contextQuery, ['cliente' => '__CLIENTE_ID__']))),
         csrfToken: '{{ csrf_token() }}',
         selected: {},
         form: {},


### PR DESCRIPTION
## Summary
- ensure supervisor mobile client views reuse the supervisor context in navigation links
- update supervisor fetch endpoints to build URLs with the existing route names and context

## Testing
- php artisan test *(fails: No application encryption key configured and seed data missing for sqlite fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68d385a1b3c88325bd1529f91dd1683b