### PR TITLE
feat: enable supervisor schedule management and search

### DIFF
--- a/resources/views/mobile/ejecutivo/venta/venta.blade.php
+++ b/resources/views/mobile/ejecutivo/venta/venta.blade.php
@@ -114,8 +114,6 @@
                 <div class="flex items-center gap-2 shrink-0">
                   {{-- Botón detalles "D" --}}
                   {!! $pill(!empty($s['id']) ? route('mobile.supervisor.venta', array_merge($supervisorContextQuery ?? [], ['supervisor' => $s['id']])) : '#', 'D') !!}
-                  {{-- Botón venta "V" --}}
-                  {!! $pill(route('mobile.ejecutivo.desembolso', $supervisorContextQuery ?? []), 'V') !!}
                 </div>
               </div>
 

--- a/resources/views/mobile/supervisor/busqueda/busqueda.blade.php
+++ b/resources/views/mobile/supervisor/busqueda/busqueda.blade.php
@@ -1,73 +1,13 @@
 <x-layouts.mobile.mobile-layout title="Búsqueda">
-    @php
-        $faker = \Faker\Factory::create('es_MX');
-        $fake = [
-            'clientes' => collect(range(1, 5))->map(function ($i) use ($faker) {
-                return [
-                    'nombre'         => $faker->name(),
-                    'telefono'       => $faker->phoneNumber(),
-                    'domicilio'      => $faker->streetAddress() . ', ' . $faker->city(),
-                    'promotor'       => [
-                        'nombre'    => $faker->name(),
-                        'email'     => $faker->safeEmail(),
-                        'telefono'  => $faker->phoneNumber(),
-                        'domicilio' => $faker->streetAddress() . ', ' . $faker->city(),
-                    ],
-                    'tipo_credito'   => $faker->randomElement(['activo', 'en falla']),
-                    'monto_credito'  => $faker->numberBetween(3000, 20000),
-                    'fecha_creacion' => $faker->date('Y-m-d'),
-                    'status'         => $faker->randomElement(['activo_con_deuda','activo_sin_deuda','liquidado','deudor']),
-                    'deuda'          => $faker->randomFloat(2, 100, 5000),
-                    'deuda_interes'  => $faker->randomFloat(2, 100, 5000),
-                    'fotos'          => [
-                        asset('imagenes_kualifin_propuestas/' . $faker->numberBetween(1,11) . '.jpg'),
-                        asset('imagenes_kualifin_propuestas/' . $faker->numberBetween(1,11) . '.jpg'),
-                    ],
-                    'garantia'       => asset('imagenes_kualifin_propuestas/' . $faker->numberBetween(1,11) . '.jpg'),
-                    'aval'           => [
-                        'nombre'    => $faker->name(),
-                        'email'     => $faker->safeEmail(),
-                        'telefono'  => $faker->phoneNumber(),
-                        'domicilio' => $faker->streetAddress() . ', ' . $faker->city(),
-                    ],
-                ];
-            })->toArray(),
-            'promotores' => collect(range(1, 5))->map(function ($i) use ($faker) {
-                return [
-                    'nombre'    => $faker->name(),
-                    'email'     => $faker->safeEmail(),
-                    'telefono'  => $faker->phoneNumber(),
-                    'domicilio' => $faker->streetAddress() . ', ' . $faker->city(),
-                ];
-            })->toArray(),
-        ];
-
-        $query = request('q');
-        $resultados = [];
-
-        if ($query) {
-            foreach ($fake as $tipo => $lista) {
-                foreach ($lista as $item) {
-                    if (
-                        stripos($item['nombre'], $query) !== false ||
-                        (isset($item['email']) && stripos($item['email'], $query) !== false)
-                    ) {
-                        $resultados[] = array_merge($item, ['tipo' => $tipo]);
-                    }
-                }
-            }
-        }
-    @endphp
-
     <div class="bg-white rounded-2xl shadow-md p-6 w-full max-w-md space-y-6">
         <h1 class="text-xl font-bold text-gray-900 text-center">Ingresa tu búsqueda</h1>
 
-        <form method="GET" class="space-y-4">
+        <form method="GET" action="{{ route('mobile.supervisor.busqueda', array_merge($supervisorContextQuery ?? [], [])) }}" class="space-y-4">
             <input
                 type="text"
                 name="q"
                 value="{{ $query }}"
-                placeholder="Buscar..."
+                placeholder="Buscar por nombre o dirección..."
                 class="w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
             />
             <div class="flex justify-between gap-4">
@@ -76,107 +16,164 @@
                     class="flex-1 py-2 bg-blue-800 text-white font-semibold rounded-lg hover:bg-blue-900 shadow-sm"
                 >Buscar</button>
                 <a
-                    href="{{ route('mobile.supervisor.index') }}"
+                    href="{{ route('mobile.supervisor.index', array_merge($supervisorContextQuery ?? [], [])) }}"
                     class="flex-1 py-2 text-center bg-gray-300 text-gray-700 font-semibold rounded-lg hover:bg-gray-400"
                 >Regresar</a>
             </div>
         </form>
 
-        @if($query)
-            @php
-                $clientes = collect($resultados)->where('tipo', 'clientes');
-                $promotores = collect($resultados)->where('tipo', 'promotores');
-            @endphp
+        @if($query !== '')
+            <div class="space-y-4">
+                @if(!$puedeBuscar)
+                    <p class="text-sm text-gray-500">No hay promotores asociados al supervisor seleccionado.</p>
+                @else
+                    <p class="text-sm text-gray-500">
+                        Se encontraron <span class="font-semibold text-gray-700">{{ $resultados->count() }}</span> coincidencias para "{{ $query }}".
+                    </p>
 
-            @if($clientes->count())
-                <h2 class="text-lg font-bold text-gray-900">Clientes</h2>
-                <div class="space-y-2">
-                    @foreach($clientes as $r)
-                        <div x-data="{ open: false, detail: false }" class="border border-gray-200 rounded">
-                            <div class="flex items-center justify-between p-2 cursor-pointer" @click="open = !open">
-                                <p class="font-semibold text-gray-800">{{ $r['nombre'] }}</p>
-                                <a href="#" @click.stop="detail = true" class="px-3 py-1 text-sm font-semibold text-white bg-blue-600 rounded">D</a>
-                            </div>
-                            <div x-show="open" x-cloak class="p-2 text-sm text-gray-700 space-y-1">
-                                <p><span class="font-semibold">Domicilio:</span> {{ $r['domicilio'] }}</p>
-                                <p><span class="font-semibold">Promotor:</span> {{ $r['promotor']['nombre'] }}</p>
-                                <p><span class="font-semibold">Tipo de crédito:</span> {{ ucfirst($r['tipo_credito']) }}</p>
-                                <p><span class="font-semibold">Cantidad:</span> ${{ number_format($r['monto_credito'], 2) }}</p>
-                                <p><span class="font-semibold">Fecha:</span> {{ $r['fecha_creacion'] }}</p>
-                            </div>
-
-                            <div x-show="detail" x-cloak @click.self="detail = false" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-                                <div class="bg-white rounded-lg p-4 w-full max-w-md relative">
-                                    <button class="absolute top-2 right-2 text-gray-500" @click="detail = false">✕</button>
-                                    <h2 class="text-lg font-bold mb-2">{{ $r['nombre'] }}</h2>
-                                    <p class="text-sm mb-1"><span class="font-semibold">Teléfono:</span> {{ $r['telefono'] }}</p>
-                                    <p class="text-sm mb-1"><span class="font-semibold">Domicilio:</span> {{ $r['domicilio'] }}</p>
-                                    <p class="text-sm mb-2">
-                                        <span class="font-semibold">Status:</span>
-                                        @if($r['status'] === 'activo_con_deuda')
-                                            Activo con deuda: ${{ number_format($r['deuda'], 2) }}
-                                        @elseif($r['status'] === 'activo_sin_deuda')
-                                            Activo sin deuda
-                                        @elseif($r['status'] === 'liquidado')
-                                            Liquidado
-                                        @elseif($r['status'] === 'deudor')
-                                            Deudor: ${{ number_format($r['deuda_interes'], 2) }}
-                                        @endif
-                                    </p>
-                                    <div class="grid grid-cols-2 gap-2 mb-2">
-                                        @foreach($r['fotos'] as $foto)
-                                            <img src="{{ $foto }}" alt="Foto del cliente" class="rounded" />
-                                        @endforeach
-                                        <img src="{{ $r['garantia'] }}" alt="Foto de la garantía" class="rounded col-span-2" />
-                                    </div>
-                                    <div class="text-sm space-y-2">
-                                        <div>
-                                            <p class="font-semibold">Aval</p>
-                                            <p>{{ $r['aval']['nombre'] }}</p>
-                                            <p>{{ $r['aval']['telefono'] }}</p>
-                                            <p>{{ $r['aval']['domicilio'] }}</p>
+                    @if($resultados->isEmpty())
+                        <p class="text-center text-gray-500">No se encontraron resultados.</p>
+                    @else
+                        <div class="space-y-3">
+                            @foreach($resultados as $resultado)
+                                @php $detailEnabled = (bool) ($resultado['puede_detallar'] ?? false); @endphp
+                                <div x-data="{ detail: false }" class="border border-gray-200 rounded-xl shadow-sm">
+                                    <div class="flex items-start justify-between gap-3 p-3">
+                                        <div class="min-w-0 space-y-1">
+                                            <p class="text-sm font-semibold text-gray-900">{{ $resultado['nombre'] }}</p>
+                                            <p class="text-xs text-gray-600">
+                                                Estatus del crédito: <span class="font-semibold text-gray-800">{{ $resultado['estatus_credito'] }}</span>
+                                            </p>
+                                            <p class="text-xs text-gray-600">
+                                                Supervisor: <span class="font-semibold text-gray-800">{{ $resultado['supervisor'] }}</span>
+                                            </p>
+                                            <p class="text-xs text-gray-600">
+                                                Aval: <span class="font-semibold text-gray-800">{{ $resultado['aval'] }}</span>
+                                            </p>
+                                            <p class="text-[11px] text-gray-500">
+                                                Promotor: <span class="font-semibold text-gray-700">{{ $resultado['promotor'] }}</span>
+                                            </p>
                                         </div>
-                                        <div>
-                                            <p class="font-semibold">Promotor</p>
-                                            <p>{{ $r['promotor']['nombre'] }}</p>
-                                            <p>{{ $r['promotor']['email'] }}</p>
-                                            <p>{{ $r['promotor']['telefono'] }}</p>
-                                            <p>{{ $r['promotor']['domicilio'] }}</p>
+                                        <div class="flex flex-col items-end gap-2">
+                                            <button
+                                                type="button"
+                                                @click="detail = true"
+                                                class="px-3 py-1 text-sm font-semibold rounded-lg shadow-sm transition
+                                                    {{ $detailEnabled ? 'bg-blue-600 text-white hover:bg-blue-700' : 'bg-gray-200 text-gray-500 cursor-not-allowed' }}"
+                                                {{ $detailEnabled ? '' : 'disabled' }}
+                                            >Detalles</button>
+                                            @unless($detailEnabled)
+                                                <p class="text-[11px] font-medium text-red-500">Asignado a otro supervisor</p>
+                                            @endunless
+                                        </div>
+                                    </div>
+
+                                    <div x-show="detail" x-cloak @click.self="detail = false" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+                                        <div class="relative w-full max-w-md bg-white rounded-2xl shadow-xl p-5 space-y-4">
+                                            <button
+                                                class="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+                                                @click="detail = false"
+                                                type="button"
+                                            >✕</button>
+
+                                            <div class="space-y-1">
+                                                <h2 class="text-lg font-bold text-gray-900">{{ $resultado['nombre'] }}</h2>
+                                                <p class="text-xs text-gray-600">Supervisor: <span class="font-semibold text-gray-800">{{ $resultado['detalle']['supervisor'] }}</span></p>
+                                                <p class="text-xs text-gray-600">Estatus del crédito: <span class="font-semibold text-gray-800">{{ $resultado['detalle']['estatus_credito'] }}</span></p>
+                                            </div>
+
+                                            <div class="space-y-3">
+                                                <div class="space-y-1">
+                                                    <h3 class="text-sm font-semibold text-gray-900">Cliente</h3>
+                                                    @php
+                                                        $telefonosCliente = collect($resultado['detalle']['cliente']['telefonos'] ?? [])->filter()->implode(', ');
+                                                    @endphp
+                                                    <p class="text-xs text-gray-600">Teléfono(s): <span class="font-semibold text-gray-800">{{ $telefonosCliente !== '' ? $telefonosCliente : 'Sin teléfono registrado' }}</span></p>
+                                                    <p class="text-xs text-gray-600">Domicilio: <span class="font-semibold text-gray-800">{{ $resultado['detalle']['cliente']['domicilio'] ?? 'Sin domicilio registrado' }}</span></p>
+
+                                                    <div class="space-y-1">
+                                                        <p class="text-xs font-semibold text-gray-700">INE</p>
+                                                        @php $docsClienteIne = collect($resultado['detalle']['cliente']['documentos']['ine'] ?? []); @endphp
+                                                        @if($docsClienteIne->isEmpty())
+                                                            <p class="text-[11px] text-gray-400">Sin fotografías de INE.</p>
+                                                        @else
+                                                            <div class="grid grid-cols-2 gap-2">
+                                                                @foreach($docsClienteIne as $doc)
+                                                                    @if(!empty($doc['url']))
+                                                                        <img src="{{ $doc['url'] }}" alt="INE del cliente" class="rounded-lg object-cover" />
+                                                                    @endif
+                                                                @endforeach
+                                                            </div>
+                                                        @endif
+                                                    </div>
+
+                                                    <div class="space-y-1">
+                                                        <p class="text-xs font-semibold text-gray-700">Comprobante de domicilio</p>
+                                                        @php $docsClienteDom = collect($resultado['detalle']['cliente']['documentos']['comprobante'] ?? []); @endphp
+                                                        @if($docsClienteDom->isEmpty())
+                                                            <p class="text-[11px] text-gray-400">Sin comprobantes de domicilio.</p>
+                                                        @else
+                                                            <div class="grid grid-cols-2 gap-2">
+                                                                @foreach($docsClienteDom as $doc)
+                                                                    @if(!empty($doc['url']))
+                                                                        <img src="{{ $doc['url'] }}" alt="Comprobante del cliente" class="rounded-lg object-cover" />
+                                                                    @endif
+                                                                @endforeach
+                                                            </div>
+                                                        @endif
+                                                    </div>
+                                                </div>
+
+                                                <div class="space-y-1">
+                                                    <h3 class="text-sm font-semibold text-gray-900">Aval</h3>
+                                                    <p class="text-xs text-gray-600">Nombre: <span class="font-semibold text-gray-800">{{ $resultado['detalle']['aval']['nombre'] }}</span></p>
+                                                    @php
+                                                        $telefonosAval = collect($resultado['detalle']['aval']['telefonos'] ?? [])->filter()->implode(', ');
+                                                    @endphp
+                                                    <p class="text-xs text-gray-600">Teléfono(s): <span class="font-semibold text-gray-800">{{ $telefonosAval !== '' ? $telefonosAval : 'Sin teléfono registrado' }}</span></p>
+                                                    <p class="text-xs text-gray-600">Domicilio: <span class="font-semibold text-gray-800">{{ $resultado['detalle']['aval']['domicilio'] ?? 'Sin domicilio registrado' }}</span></p>
+
+                                                    <div class="space-y-1">
+                                                        <p class="text-xs font-semibold text-gray-700">INE</p>
+                                                        @php $docsAvalIne = collect($resultado['detalle']['aval']['documentos']['ine'] ?? []); @endphp
+                                                        @if($docsAvalIne->isEmpty())
+                                                            <p class="text-[11px] text-gray-400">Sin fotografías de INE del aval.</p>
+                                                        @else
+                                                            <div class="grid grid-cols-2 gap-2">
+                                                                @foreach($docsAvalIne as $doc)
+                                                                    @if(!empty($doc['url']))
+                                                                        <img src="{{ $doc['url'] }}" alt="INE del aval" class="rounded-lg object-cover" />
+                                                                    @endif
+                                                                @endforeach
+                                                            </div>
+                                                        @endif
+                                                    </div>
+
+                                                    <div class="space-y-1">
+                                                        <p class="text-xs font-semibold text-gray-700">Comprobante de domicilio</p>
+                                                        @php $docsAvalDom = collect($resultado['detalle']['aval']['documentos']['comprobante'] ?? []); @endphp
+                                                        @if($docsAvalDom->isEmpty())
+                                                            <p class="text-[11px] text-gray-400">Sin comprobantes de domicilio del aval.</p>
+                                                        @else
+                                                            <div class="grid grid-cols-2 gap-2">
+                                                                @foreach($docsAvalDom as $doc)
+                                                                    @if(!empty($doc['url']))
+                                                                        <img src="{{ $doc['url'] }}" alt="Comprobante del aval" class="rounded-lg object-cover" />
+                                                                    @endif
+                                                                @endforeach
+                                                            </div>
+                                                        @endif
+                                                    </div>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
+                            @endforeach
                         </div>
-                    @endforeach
-                </div>
-            @endif
-
-            @if($promotores->count())
-                <h2 class="text-lg font-bold text-gray-900 mt-4">Promotores</h2>
-                <div class="space-y-2">
-                    @foreach($promotores as $r)
-                        <div x-data="{ detail: false }" class="border border-gray-200 rounded">
-                            <div class="flex items-center justify-between p-2">
-                                <p class="font-semibold text-gray-800">{{ $r['nombre'] }}</p>
-                                <a href="#" @click.prevent="detail = true" class="px-3 py-1 text-sm font-semibold text-white bg-blue-600 rounded">D</a>
-                            </div>
-                            <div x-show="detail" x-cloak @click.self="detail = false" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-                                <div class="bg-white rounded-lg p-4 w-full max-w-md relative">
-                                    <button class="absolute top-2 right-2 text-gray-500" @click="detail = false">✕</button>
-                                    <h2 class="text-lg font-bold mb-2">{{ $r['nombre'] }}</h2>
-                                    <p class="text-sm"><span class="font-semibold">Email:</span> {{ $r['email'] }}</p>
-                                    <p class="text-sm"><span class="font-semibold">Teléfono:</span> {{ $r['telefono'] }}</p>
-                                    <p class="text-sm"><span class="font-semibold">Domicilio:</span> {{ $r['domicilio'] }}</p>
-                                </div>
-                            </div>
-                        </div>
-                    @endforeach
-                </div>
-            @endif
-
-            @if($clientes->isEmpty() && $promotores->isEmpty())
-                <p class="text-center text-gray-500">No se encontraron resultados.</p>
-            @endif
+                    @endif
+                @endif
+            </div>
         @endif
     </div>
 </x-layouts.mobile.mobile-layout>

--- a/resources/views/mobile/supervisor/venta/horarios_definir.blade.php
+++ b/resources/views/mobile/supervisor/venta/horarios_definir.blade.php
@@ -1,0 +1,80 @@
+<x-layouts.mobile.mobile-layout title="Definir horario">
+    <div class="mx-auto w-[22rem] sm:w-[26rem] p-4 sm:p-6 space-y-5">
+        @if (session('status'))
+            <div class="rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        <section class="bg-white rounded-2xl shadow ring-1 ring-gray-900/5 px-4 py-4 space-y-2">
+            <h1 class="text-base font-bold text-gray-900">Definir horario de cobro</h1>
+            <div class="text-sm text-gray-700 space-y-1">
+                <p>
+                    <span class="font-semibold">Promotor:</span>
+                    {{ trim(($promotor->nombre ?? '') . ' ' . ($promotor->apellido_p ?? '') . ' ' . ($promotor->apellido_m ?? '')) ?: 'Sin nombre' }}
+                </p>
+                <p>
+                    <span class="font-semibold">Supervisor:</span>
+                    {{ $supervisorNombre }}
+                </p>
+                <p>
+                    <span class="font-semibold">Horario actual:</span>
+                    {{ $diasPago !== '' ? $diasPago : 'Sin horario definido' }}
+                </p>
+            </div>
+        </section>
+
+        <form method="POST" action="{{ route('mobile.supervisor.horarios.actualizar', array_merge($supervisorContextQuery ?? [], ['promotor' => $promotor->id])) }}" class="space-y-4">
+            @csrf
+            @method('PUT')
+
+            <section class="bg-white rounded-2xl shadow ring-1 ring-gray-900/5 px-4 py-4 space-y-3">
+                <div class="space-y-2">
+                    <label for="dias_de_pago" class="text-sm font-semibold text-gray-800">Días de pago</label>
+                    <input
+                        id="dias_de_pago"
+                        type="text"
+                        name="dias_de_pago"
+                        value="{{ old('dias_de_pago', $diasPago) }}"
+                        maxlength="100"
+                        placeholder="Ej. lunes, miércoles, viernes"
+                        class="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                    />
+                    <p class="text-xs text-gray-500">Ingresa los días separados por comas. Puedes incluir horarios u observaciones si es necesario.</p>
+                    @error('dias_de_pago')
+                        <p class="text-xs font-semibold text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="text-xs text-gray-500 space-y-1">
+                    <p class="font-semibold text-gray-700">Sugerencias rápidas:</p>
+                    <div class="flex flex-wrap gap-2">
+                        @php
+                            $presets = [
+                                'Lunes y miércoles',
+                                'Martes y jueves',
+                                'Viernes',
+                                'Lunes a viernes',
+                                'Martes a sábado',
+                            ];
+                        @endphp
+                        @foreach ($presets as $preset)
+                            <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-[11px] font-semibold text-gray-600">{{ $preset }}</span>
+                        @endforeach
+                    </div>
+                </div>
+            </section>
+
+            <div class="flex items-center justify-between gap-3">
+                <a
+                    href="{{ route('mobile.supervisor.horarios', array_merge($supervisorContextQuery ?? [], [])) }}"
+                    class="inline-flex flex-1 items-center justify-center rounded-2xl border border-gray-300 px-3 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-100"
+                >Cancelar</a>
+                <button
+                    type="submit"
+                    class="inline-flex flex-1 items-center justify-center rounded-2xl bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+                >Guardar cambios</button>
+            </div>
+        </form>
+    </div>
+</x-layouts.mobile.mobile-layout>

--- a/resources/views/mobile/supervisor/venta/venta.blade.php
+++ b/resources/views/mobile/supervisor/venta/venta.blade.php
@@ -79,14 +79,14 @@
                 <div class="w-full bg-gray-200 rounded-full h-2">
                     <div class="bg-red-500 h-2 rounded-full" style="width: {{ min(100, $p['porcentajeFalla']) }}%"></div>
                 </div>
-                 <div class="flex">
-                    <div class="w-80">
+                <div class="flex items-start justify-between gap-3">
+                    <div class="flex-1">
                         <p class="text-xs font-semibold">{{ number_format($p['porcentajeFalla'], 0) }}% Falla</p>
                         <p class="text-sm">Venta Registrada: <span class="font-bold">{{ formatCurrency($p['ventaRegistrada']) }}</span></p>
                     </div>
-                    <div>
-                        {{-- <a href="{{ route('mobile.supervisor.cartera_promotor', $p->id) }}" class="px-3 py-1 text-right text-sm font-semibold text-white bg-blue-600 rounded">D</a> --}}
-                        <a href="{{ route('mobile.promotor.venta', array_merge($supervisorContextQuery ?? [], ['promotor' => $p['id']])) }}" class="px-3 py-1 text-right text-sm font-semibold text-white bg-blue-600 rounded">D</a>
+                    <div class="flex flex-col items-end gap-2">
+                        <a href="{{ route('mobile.promotor.venta', array_merge($supervisorContextQuery ?? [], ['promotor' => $p['id']])) }}" class="px-3 py-1 text-sm font-semibold text-white bg-blue-600 rounded">D</a>
+                        <a href="{{ route('mobile.ejecutivo.desembolso', array_merge($supervisorContextQuery ?? [], [])) }}" class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 rounded">V</a>
                     </div>
                 </div>
                 <div class="grid grid-cols-2 gap-4 text-xs">

--- a/routes/web.php
+++ b/routes/web.php
@@ -122,8 +122,10 @@ Route::middleware(['auth','verified'])->group(function () {
                       Route::post('clientes-supervisados/{cliente}/registrar-credito', [NuevoClienteController::class, 'RegistrarCredito'])->name('clientes_prospectados.registrar_credito');
                       Route::get('clientes-supervisados',    'clientes_supervisados')    ->name('clientes_supervisados');
                       Route::get('busqueda',          'busqueda')          ->name('busqueda');
-                      Route::get('apertura',          'apertura')          ->name('apertura');  
+                      Route::get('apertura',          'apertura')          ->name('apertura');
                       Route::get('venta/horarios', 'horarios')                   ->name('horarios');
+                      Route::get('venta/horarios/{promotor}', 'horariosDefinir') ->name('horarios.definir');
+                      Route::put('venta/horarios/{promotor}', 'horariosActualizar')->name('horarios.actualizar');
                   });
          });
 


### PR DESCRIPTION
## Summary
- allow supervisors to define payment days for each promotor with new form and persistence
- wire up supervisor search to return real client results with detailed modal info and supervisor access checks
- relocate the desembolso "V" action from the ejecutivo dashboard to each promotor card in the supervisor view

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d39ad5a0d48325a97d0c6a4dbf17ad