### PR TITLE
Fix supervisor search credit query ambiguity

### DIFF
--- a/app/Http/Controllers/SupervisorController.php
+++ b/app/Http/Controllers/SupervisorController.php
@@ -1310,7 +1310,15 @@ class SupervisorController extends Controller
                     'promotor:id,supervisor_id,nombre,apellido_p,apellido_m',
                     'promotor.supervisor:id,nombre,apellido_p,apellido_m',
                     'credito' => function ($creditoQuery) {
-                        $creditoQuery->select('id', 'cliente_id', 'estado', 'monto_total', 'periodicidad', 'fecha_inicio', 'fecha_final')
+                        $creditoQuery->select(
+                            'creditos.id',
+                            'creditos.cliente_id',
+                            'creditos.estado',
+                            'creditos.monto_total',
+                            'creditos.periodicidad',
+                            'creditos.fecha_inicio',
+                            'creditos.fecha_final'
+                        )
                             ->with([
                                 'datoContacto:id,credito_id,calle,numero_ext,numero_int,colonia,municipio,estado,cp,tel_fijo,tel_cel',
                                 'avales:id,credito_id,CURP,nombre,apellido_p,apellido_m,telefono,direccion',


### PR DESCRIPTION
## Summary
- qualify credito select columns in the supervisor search eager load to avoid ambiguous column errors when joining latest credit

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a2ab7cc88325ba8947f49ccdfa98