### PR TITLE
Replace promotores payment day with day and time fields

### DIFF
--- a/app/Http/Controllers/EjecutivoController.php
+++ b/app/Http/Controllers/EjecutivoController.php
@@ -279,7 +279,7 @@ class EjecutivoController extends Controller
     {
         return [
             'promotores' => function ($query) {
-                $query->select('id', 'supervisor_id', 'nombre', 'apellido_p', 'apellido_m', 'venta_maxima', 'venta_proyectada_objetivo', 'dias_de_pago')
+                $query->select('id', 'supervisor_id', 'nombre', 'apellido_p', 'apellido_m', 'venta_maxima', 'venta_proyectada_objetivo', 'dia_de_pago', 'hora_de_pago')
                     ->with(['clientes' => function ($clienteQuery) {
                         $clienteQuery->select('id', 'promotor_id');
                     }])

--- a/app/Models/Promotor.php
+++ b/app/Models/Promotor.php
@@ -1,8 +1,11 @@
 <?php
 namespace App\Models;
 
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 class Promotor extends Model
 {
@@ -12,8 +15,96 @@ class Promotor extends Model
     const UPDATED_AT = 'actualizado_en';
     protected $table = 'promotores';
     protected $casts = [
-        'dias_de_pago' => 'string',
+        'dia_de_pago' => 'string',
     ];
+
+    protected $appends = ['horario_pago_resumen'];
+
+    protected function horaDePago(): Attribute
+    {
+        return Attribute::make(
+            get: function ($value) {
+                if ($value instanceof CarbonInterface) {
+                    return $value->format('H:i');
+                }
+
+                if (is_string($value)) {
+                    $value = trim($value);
+
+                    if ($value === '') {
+                        return null;
+                    }
+
+                    if (preg_match('/^\d{2}:\d{2}/', $value, $matches)) {
+                        return $matches[0];
+                    }
+
+                    try {
+                        return Carbon::parse($value)->format('H:i');
+                    } catch (\Throwable) {
+                        return null;
+                    }
+                }
+
+                return null;
+            },
+            set: function ($value) {
+                if ($value instanceof CarbonInterface) {
+                    return $value->format('H:i:s');
+                }
+
+                if (is_string($value)) {
+                    $value = trim($value);
+
+                    if ($value === '') {
+                        return null;
+                    }
+
+                    if (preg_match('/^\d{2}:\d{2}$/', $value)) {
+                        return $value . ':00';
+                    }
+
+                    if (preg_match('/^\d{2}:\d{2}:\d{2}$/', $value)) {
+                        return $value;
+                    }
+
+                    try {
+                        return Carbon::parse($value)->format('H:i:s');
+                    } catch (\Throwable) {
+                        return null;
+                    }
+                }
+
+                return null;
+            }
+        );
+    }
+
+    public function getHorarioPagoResumenAttribute(): string
+    {
+        $dia = trim((string) ($this->dia_de_pago ?? ''));
+        $hora = $this->hora_de_pago;
+
+        if ($hora instanceof CarbonInterface) {
+            $hora = $hora->format('H:i');
+        }
+
+        if (is_string($hora)) {
+            $hora = trim($hora);
+        } else {
+            $hora = '';
+        }
+
+        if ($dia === '' && $hora === '') {
+            return '';
+        }
+
+        if ($dia !== '' && $hora !== '') {
+            return sprintf('%s • %s', $dia, $hora);
+        }
+
+        return $dia !== '' ? $dia : $hora;
+    }
 
     public function user()
     {

--- a/database/migrations/2025_09_24_225528_update_promotores_payment_schedule.php
+++ b/database/migrations/2025_09_24_225528_update_promotores_payment_schedule.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('promotores', function (Blueprint $table) {
+            $table->string('dia_de_pago', 50)
+                ->nullable()
+                ->after('bono');
+            $table->time('hora_de_pago')
+                ->nullable()
+                ->after('dia_de_pago');
+        });
+
+        Schema::table('promotores', function (Blueprint $table) {
+            $table->dropColumn('dias_de_pago');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('promotores', function (Blueprint $table) {
+            $table->string('dias_de_pago', 100)
+                ->nullable()
+                ->comment('Días en los que el promotor realiza cobros programados')
+                ->after('bono');
+            $table->dropColumn(['dia_de_pago', 'hora_de_pago']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -97,12 +97,13 @@ class DatabaseSeeder extends Seeder
         ]);
 
         $faker = fake();
-        $diasPagoOptions = [
-            'lunes, miércoles',
-            'martes, jueves',
-            'viernes',
-            'lunes a viernes',
-            'martes a sábado',
+        $horariosPago = [
+            ['dia' => 'Lunes', 'hora' => '08:00'],
+            ['dia' => 'Martes', 'hora' => '09:30'],
+            ['dia' => 'Miércoles', 'hora' => '11:00'],
+            ['dia' => 'Jueves', 'hora' => '13:30'],
+            ['dia' => 'Viernes', 'hora' => '16:00'],
+            ['dia' => 'Sábado', 'hora' => '12:00'],
         ];
 
         for ($i = 1; $i <= 10; $i++) {
@@ -158,6 +159,8 @@ class DatabaseSeeder extends Seeder
             ]);
             $promotorUser->assignRole('promotor');
 
+            $horario = $faker->randomElement($horariosPago);
+
             Promotor::create([
                 'user_id' => $promotorUser->id,
                 'supervisor_id' => $supervisor->id,
@@ -168,7 +171,8 @@ class DatabaseSeeder extends Seeder
                 'colonia' => $faker->streetName(),
                 'venta_proyectada_objetivo' => $faker->randomElement([3000, 4000, 5000, 6000, 7000, 8000, 10000, 12000, 15000, 20000]),
                 'bono' => $faker->randomFloat(2, 200, 1500),
-                'dias_de_pago' => $faker->randomElement($diasPagoOptions),
+                'dia_de_pago' => $horario['dia'],
+                'hora_de_pago' => $horario['hora'],
             ]);
         }
 
@@ -182,6 +186,8 @@ class DatabaseSeeder extends Seeder
             'rol' => 'promotor',
         ]);
         $user->assignRole('promotor');
+        $horarioPromotorDemo = $horariosPago[0];
+
         $promotor = Promotor::create([
             'user_id' => $user->id,
             'supervisor_id' => $supervisor->id,
@@ -192,7 +198,8 @@ class DatabaseSeeder extends Seeder
             'colonia' => 'Centro',
             'venta_proyectada_objetivo' => 5000,
             'bono' => 500,
-            'dias_de_pago' => 'lunes, miércoles',
+            'dia_de_pago' => $horarioPromotorDemo['dia'],
+            'hora_de_pago' => $horarioPromotorDemo['hora'],
         ]);
 
         $faker = fake();

--- a/database/seeders/PromotorSeeder.php
+++ b/database/seeders/PromotorSeeder.php
@@ -22,12 +22,13 @@ class PromotorSeeder extends Seeder
 
         $this->command->info('Creando 20 promotores con logins de prueba...');
 
-        $diasPagoOptions = [
-            'lunes, miércoles',
-            'martes, jueves',
-            'viernes',
-            'lunes a viernes',
-            'martes a sábado',
+        $horariosPago = [
+            ['dia' => 'Lunes', 'hora' => '08:00'],
+            ['dia' => 'Martes', 'hora' => '09:30'],
+            ['dia' => 'Miércoles', 'hora' => '11:00'],
+            ['dia' => 'Jueves', 'hora' => '13:30'],
+            ['dia' => 'Viernes', 'hora' => '16:00'],
+            ['dia' => 'Sábado', 'hora' => '12:00'],
         ];
 
         for ($i = 1; $i <= 20; $i++) {
@@ -45,6 +46,8 @@ class PromotorSeeder extends Seeder
             ]);
 
             // Crear promotor asociado
+            $horario = fake()->randomElement($horariosPago);
+
             Promotor::create([
                 'user_id' => $user->id,
                 'supervisor_id' => $supervisores->random()->id,
@@ -55,7 +58,8 @@ class PromotorSeeder extends Seeder
                 'colonia' => fake()->streetName(),
                 'venta_proyectada_objetivo' => fake()->randomFloat(2, 1000, 10000),
                 'bono' => fake()->randomFloat(2, 100, 1000),
-                'dias_de_pago' => fake()->randomElement($diasPagoOptions),
+                'dia_de_pago' => $horario['dia'],
+                'hora_de_pago' => $horario['hora'],
             ]);
 
             $user->assignRole('promotor');

--- a/resources/views/mobile/ejecutivo/cartera/cartera_activa.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_activa.blade.php
@@ -37,12 +37,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-indigo-100 text-indigo-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div class="flex flex-col">
                             <span class="text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile/ejecutivo/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_falla.blade.php
@@ -14,12 +14,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-red-100 text-red-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile/ejecutivo/cartera/cartera_inactiva.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_inactiva.blade.php
@@ -12,12 +12,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-gray-200 text-gray-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile/ejecutivo/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_vencida.blade.php
@@ -16,12 +16,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-orange-100 text-orange-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile/ejecutivo/cartera/promotor.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/promotor.blade.php
@@ -3,10 +3,10 @@
     <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
       <div class="p-5">
         <h2 class="text-base font-bold text-gray-900 mb-3">{{ $promotor->nombre }} {{ $promotor->apellido_p }} {{ $promotor->apellido_m }}</h2>
-        @php $diasPago = trim((string) ($promotor->dias_de_pago ?? '')); @endphp
-        @if($diasPago !== '')
-          <p class="text-xs text-gray-500 mb-4">Días de pago: {{ $diasPago }}</p>
-        @endif
+        @php $horarioPago = trim((string) ($promotor->horario_pago_resumen ?? '')); @endphp
+          @if($horarioPago !== '')
+            <p class="text-xs text-gray-500 mb-4">Horario de pago: {{ $horarioPago }}</p>
+          @endif
         <div class="space-y-3">
           @forelse($clientes as $c)
             <a href="{{ route('mobile.supervisor.cliente_historial', $c->id) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">

--- a/resources/views/mobile/ejecutivo/venta/horarios.blade.php
+++ b/resources/views/mobile/ejecutivo/venta/horarios.blade.php
@@ -1,6 +1,7 @@
 {{-- resources/views/mobile/supervisor/venta/definir_horarios.blade.php --}}
 @php
   use Carbon\Carbon;
+  use Illuminate\Support\Str;
 
   /** ===== Vars con defaults seguros ===== */
   $role         = $role ?? 'supervisor';
@@ -66,14 +67,25 @@
                 {{ trim(($p->nombre ?? '').' '.($p->apellido_p ?? '').' '.($p->apellido_m ?? '')) ?: ($p->nombre_completo ?? '—') }}
               </span>
             </div>
-            <form method="POST" action="{{ $definirRoute($p->id ?? 0) }}" class="ml-8 flex items-center gap-2">
+            @php $horarioPago = trim((string) ($p->horario_pago_resumen ?? '')); @endphp
+            @if($horarioPago !== '')
+              <p class="ml-8 text-xs text-gray-500">Horario actual: {{ $horarioPago }}</p>
+            @endif
+            <form method="POST" action="{{ $definirRoute($p->id ?? 0) }}" class="ml-8 flex flex-wrap items-center gap-2">
               @csrf
-              <select name="dia_pago" class="text-sm rounded-lg border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500">
+              <select name="dia_de_pago" class="text-sm rounded-lg border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500">
                 <option value="">Seleccionar día</option>
                 @foreach($diasSemana as $dia)
-                  <option value="{{ $dia }}" @selected(($p->dias_de_pago ?? '') === $dia)>{{ $dia }}</option>
+                  <option value="{{ $dia }}" @selected(Str::lower($p->dia_de_pago ?? '') === Str::lower($dia))>{{ $dia }}</option>
                 @endforeach
               </select>
+              <input
+                type="time"
+                name="hora_de_pago"
+                value="{{ $p->hora_de_pago }}"
+                class="text-sm rounded-lg border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
+                required
+              />
               <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white text-xs px-3 py-1.5 rounded-lg shadow">
                 Guardar
               </button>

--- a/resources/views/mobile/supervisor/Apertura/apertura.blade.php
+++ b/resources/views/mobile/supervisor/Apertura/apertura.blade.php
@@ -2,12 +2,10 @@
 <x-layouts.mobile.mobile-layout title="Alta de Promotor">
 @php
     $faker = \Faker\Factory::create('es_MX');
-    $diasPagoEjemplo = $faker->randomElement([
-        'lunes, miércoles',
-        'martes, jueves',
-        'viernes',
-        'lunes a viernes',
-    ]);
+    $diasPagoEjemplo = [
+        'dia' => $faker->randomElement(['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes']),
+        'hora' => $faker->randomElement(['08:00', '09:30', '11:00', '13:30', '16:00']),
+    ];
 @endphp
     <div
         x-data="{
@@ -15,7 +13,8 @@
             domicilio: '',
             telefono: '',
             correo: '',
-            diasPago: @json($diasPagoEjemplo),
+            diaPago: @json($diasPagoEjemplo['dia']),
+            horaPago: @json($diasPagoEjemplo['hora']),
             ineUploaded: false,
             compUploaded: false,
             submit() {
@@ -29,6 +28,14 @@
                 }
                 if (!this.correo.trim()) {
                     alert('Falta el campo Correo electrónico');
+                    return;
+                }
+                if (!this.diaPago.trim()) {
+                    alert('Falta seleccionar el día de pago');
+                    return;
+                }
+                if (!this.horaPago) {
+                    alert('Falta capturar la hora de pago');
                     return;
                 }
                 if (!this.ineUploaded) {
@@ -45,7 +52,8 @@
                 this.domicilio = '';
                 this.telefono = '';
                 this.correo = '';
-                this.diasPago = '';
+                this.diaPago = '';
+                this.horaPago = '';
                 this.ineUploaded = false;
                 this.compUploaded = false;
             }
@@ -94,15 +102,34 @@
                 />
             </div>
 
-            <div>
-                <label class="block text-sm font-medium text-gray-700">Días de pago</label>
-                <input
-                    type="text"
-                    x-model="diasPago"
-                    placeholder="Ej. lunes, miércoles"
-                    class="mt-1 w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-                />
-                <p class="mt-1 text-xs text-gray-500">Indica los días habituales de cobro separados por comas.</p>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">Día de pago</label>
+                    <select
+                        x-model="diaPago"
+                        class="mt-1 w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                    >
+                        <option value="">Selecciona un día</option>
+                        <option value="Lunes">Lunes</option>
+                        <option value="Martes">Martes</option>
+                        <option value="Miércoles">Miércoles</option>
+                        <option value="Jueves">Jueves</option>
+                        <option value="Viernes">Viernes</option>
+                        <option value="Sábado">Sábado</option>
+                        <option value="Domingo">Domingo</option>
+                    </select>
+                    <p class="mt-1 text-xs text-gray-500">Elige el día habitual para realizar los cobros.</p>
+                </div>
+
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">Hora de pago</label>
+                    <input
+                        type="time"
+                        x-model="horaPago"
+                        class="mt-1 w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                    />
+                    <p class="mt-1 text-xs text-gray-500">Registra la hora (formato 24 hrs) en la que inicia la ruta.</p>
+                </div>
             </div>
 
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/resources/views/mobile/supervisor/cartera/cartera.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera.blade.php
@@ -66,10 +66,10 @@
                     <span class="text-sm font-semibold text-gray-900">
                       {{ $p->nombre }} {{ $p->apellido_p }} {{ $p->apellido_m }}
                     </span>
-                    @php $diasPago = trim((string) ($p->dias_de_pago ?? '')); @endphp
-                    @if($diasPago !== '')
-                      <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
-                    @endif
+                    @php $horarioPago = trim((string) ($p->horario_pago_resumen ?? '')); @endphp
+                      @if($horarioPago !== '')
+                      <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
+                      @endif
                   </div>
                 </div>
               </div>

--- a/resources/views/mobile/supervisor/cartera/cartera_activa.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_activa.blade.php
@@ -37,12 +37,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-indigo-100 text-indigo-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div class="flex flex-col">
                             <span class="text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile/supervisor/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_falla.blade.php
@@ -14,12 +14,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-red-100 text-red-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile/supervisor/cartera/cartera_inactiva.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_inactiva.blade.php
@@ -12,12 +12,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-gray-200 text-gray-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile/supervisor/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile/supervisor/cartera/cartera_vencida.blade.php
@@ -16,12 +16,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-orange-100 text-orange-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile/supervisor/cartera/promotor.blade.php
+++ b/resources/views/mobile/supervisor/cartera/promotor.blade.php
@@ -3,10 +3,10 @@
     <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
       <div class="p-5">
         <h2 class="text-base font-bold text-gray-900 mb-3">{{ $promotor->nombre }} {{ $promotor->apellido_p }} {{ $promotor->apellido_m }}</h2>
-        @php $diasPago = trim((string) ($promotor->dias_de_pago ?? '')); @endphp
-        @if($diasPago !== '')
-          <p class="text-xs text-gray-500 mb-4">Días de pago: {{ $diasPago }}</p>
-        @endif
+        @php $horarioPago = trim((string) ($promotor->horario_pago_resumen ?? '')); @endphp
+          @if($horarioPago !== '')
+            <p class="text-xs text-gray-500 mb-4">Horario de pago: {{ $horarioPago }}</p>
+          @endif
         <div class="space-y-3">
           @forelse($clientes as $c)
             <a href="{{ route('mobile.supervisor.cliente_historial', array_merge($supervisorContextQuery ?? [], ['cliente' => $c->id])) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">

--- a/resources/views/mobile/supervisor/venta/horarios.blade.php
+++ b/resources/views/mobile/supervisor/venta/horarios.blade.php
@@ -79,9 +79,9 @@
                   {{ trim(($p->nombre ?? '').' '.($p->apellido_p ?? '').' '.($p->apellido_m ?? '')) ?: ($p->nombre_completo ?? '—') }}
                 </span>
               </div>
-              @php $diasPago = trim((string) ($p->dias_de_pago ?? '')); @endphp
-              @if($diasPago !== '')
-                <p class="ml-8 text-xs text-gray-500">Días de pago: {{ $diasPago }}</p>
+              @php $horarioPago = trim((string) ($p->horario_pago_resumen ?? '')); @endphp
+              @if($horarioPago !== '')
+                <p class="ml-8 text-xs text-gray-500">Horario de pago: {{ $horarioPago }}</p>
               @endif
             </div>
             {!! $btn($definirRoute($p->id ?? 0), 'Definir', 'indigo', 'sm') !!}

--- a/resources/views/mobile/supervisor/venta/horarios_definir.blade.php
+++ b/resources/views/mobile/supervisor/venta/horarios_definir.blade.php
@@ -1,7 +1,10 @@
 <x-layouts.mobile.mobile-layout title="Definir horario">
     @php
+        use Illuminate\Support\Str;
+
         $diasSemana = ['Lunes','Martes','Miércoles','Jueves','Viernes','Sábado','Domingo'];
-        $seleccionActual = old('dias_de_pago', $diasPago ?? '');
+        $diaSeleccionado = old('dia_de_pago', $diaPago ?? '');
+        $horaSeleccionada = old('hora_de_pago', $horaPago ?? '');
     @endphp
 
     <div class="mx-auto w-[22rem] sm:w-[26rem] p-4 sm:p-6 space-y-5">
@@ -24,7 +27,10 @@
                 </p>
                 <p>
                     <span class="font-semibold">Horario actual:</span>
-                    {{ $diasPago !== '' ? $diasPago : 'Sin horario definido' }}
+                    @php
+                        $horarioActual = trim((string) ($promotor->horario_pago_resumen ?? ''));
+                    @endphp
+                    {{ $horarioActual !== '' ? $horarioActual : 'Sin horario definido' }}
                 </p>
             </div>
         </section>
@@ -39,17 +45,17 @@
 
             <section class="bg-white rounded-2xl shadow ring-1 ring-gray-900/5 px-4 py-4 space-y-3">
                 <div class="space-y-2">
-                    <label for="dias_de_pago" class="text-sm font-semibold text-gray-800">Día de pago</label>
+                    <label for="dia_de_pago" class="text-sm font-semibold text-gray-800">Día de pago</label>
 
                     <select
-                        id="dias_de_pago"
-                        name="dias_de_pago"
+                        id="dia_de_pago"
+                        name="dia_de_pago"
                         class="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
                         required
                     >
-                        <option value="" @selected($seleccionActual === '' )>Selecciona un día</option>
+                        <option value="" @selected($diaSeleccionado === '' )>Selecciona un día</option>
                         @foreach($diasSemana as $dia)
-                            <option value="{{ $dia }}" @selected(Str::lower($seleccionActual) === Str::lower($dia))>
+                            <option value="{{ $dia }}" @selected(Str::lower($diaSeleccionado) === Str::lower($dia))>
                                 {{ $dia }}
                             </option>
                         @endforeach
@@ -57,7 +63,26 @@
 
                     <p class="text-xs text-gray-500">Elige exactamente un día de la semana.</p>
 
-                    @error('dias_de_pago')
+                    @error('dia_de_pago')
+                        <p class="text-xs font-semibold text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="space-y-2">
+                    <label for="hora_de_pago" class="text-sm font-semibold text-gray-800">Hora de pago</label>
+
+                    <input
+                        id="hora_de_pago"
+                        name="hora_de_pago"
+                        type="time"
+                        class="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        value="{{ $horaSeleccionada }}"
+                        required
+                    />
+
+                    <p class="text-xs text-gray-500">Registra la hora en formato 24 horas (HH:MM).</p>
+
+                    @error('hora_de_pago')
                         <p class="text-xs font-semibold text-red-600">{{ $message }}</p>
                     @enderror
                 </div>

--- a/resources/views/mobile_legacy/ejecutivo/cartera/cartera_activa.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/cartera/cartera_activa.blade.php
@@ -37,13 +37,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-indigo-100 text-indigo-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div class="flex flex-col">
                             <span class="text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
-                            @endif
+                                @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
+                                @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile_legacy/ejecutivo/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/cartera/cartera_falla.blade.php
@@ -14,13 +14,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-red-100 text-red-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
-                            @endif
+                                @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
+                                @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile_legacy/ejecutivo/cartera/cartera_inactiva.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/cartera/cartera_inactiva.blade.php
@@ -12,13 +12,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-gray-200 text-gray-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
-                            @endif
+                                @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
+                                @endif
                         </div>
                     </div>
                 </div>

--- a/resources/views/mobile_legacy/ejecutivo/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/cartera/cartera_vencida.blade.php
@@ -16,13 +16,13 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-orange-100 text-orange-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
-                            @endif
+                                @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
+                                @endif
                         </div>
                     </div>
                     <div class="text-right">

--- a/resources/views/mobile_legacy/ejecutivo/cartera/promotor.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/cartera/promotor.blade.php
@@ -3,10 +3,10 @@
     <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
       <div class="p-5">
         <h2 class="text-base font-bold text-gray-900 mb-3">{{ $promotor->nombre }} {{ $promotor->apellido_p }} {{ $promotor->apellido_m }}</h2>
-        @php $diasPago = trim((string) ($promotor->dias_de_pago ?? '')); @endphp
-        @if($diasPago !== '')
-          <p class="text-xs text-gray-500 mb-4">Días de pago: {{ $diasPago }}</p>
-        @endif
+        @php $horarioPago = trim((string) ($promotor->horario_pago_resumen ?? '')); @endphp
+          @if($horarioPago !== '')
+            <p class="text-xs text-gray-500 mb-4">Horario de pago: {{ $horarioPago }}</p>
+          @endif
         <div class="space-y-3">
           @forelse($clientes as $c)
             <a href="{{ route('mobile.supervisor.cliente_historial', $c->id) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">

--- a/resources/views/mobile_legacy/ejecutivo/venta/horarios.blade.php
+++ b/resources/views/mobile_legacy/ejecutivo/venta/horarios.blade.php
@@ -74,9 +74,9 @@
                   {{ trim(($p->nombre ?? '').' '.($p->apellido_p ?? '').' '.($p->apellido_m ?? '')) ?: ($p->nombre_completo ?? '—') }}
                 </span>
               </div>
-              @php $diasPago = trim((string) ($p->dias_de_pago ?? '')); @endphp
-              @if($diasPago !== '')
-                <p class="ml-8 text-xs text-gray-500">Días de pago: {{ $diasPago }}</p>
+              @php $horarioPago = trim((string) ($p->horario_pago_resumen ?? '')); @endphp
+              @if($horarioPago !== '')
+                <p class="ml-8 text-xs text-gray-500">Horario de pago: {{ $horarioPago }}</p>
               @endif
             </div>
             {!! $btn($definirRoute($p->id ?? 0), 'Definir', 'indigo', 'sm') !!}

--- a/resources/views/mobile_legacy/supervisor/Apertura/apertura.blade.php
+++ b/resources/views/mobile_legacy/supervisor/Apertura/apertura.blade.php
@@ -2,12 +2,10 @@
 <x-layouts.mobile.mobile-layout title="Alta de Promotor">
 @php
     $faker = \Faker\Factory::create('es_MX');
-    $diasPagoEjemplo = $faker->randomElement([
-        'lunes, miércoles',
-        'martes, jueves',
-        'viernes',
-        'lunes a viernes',
-    ]);
+    $diasPagoEjemplo = [
+        'dia' => $faker->randomElement(['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes']),
+        'hora' => $faker->randomElement(['08:00', '09:30', '11:00', '13:30', '16:00']),
+    ];
 @endphp
     <div
         x-data="{
@@ -15,7 +13,8 @@
             domicilio: '',
             telefono: '',
             correo: '',
-            diasPago: @json($diasPagoEjemplo),
+            diaPago: @json($diasPagoEjemplo['dia']),
+            horaPago: @json($diasPagoEjemplo['hora']),
             ineUploaded: false,
             compUploaded: false,
             submit() {
@@ -29,6 +28,14 @@
                 }
                 if (!this.correo.trim()) {
                     alert('Falta el campo Correo electrónico');
+                    return;
+                }
+                if (!this.diaPago.trim()) {
+                    alert('Falta seleccionar el día de pago');
+                    return;
+                }
+                if (!this.horaPago) {
+                    alert('Falta capturar la hora de pago');
                     return;
                 }
                 if (!this.ineUploaded) {
@@ -45,7 +52,8 @@
                 this.domicilio = '';
                 this.telefono = '';
                 this.correo = '';
-                this.diasPago = '';
+                this.diaPago = '';
+                this.horaPago = '';
                 this.ineUploaded = false;
                 this.compUploaded = false;
             }
@@ -94,15 +102,34 @@
                 />
             </div>
 
-            <div>
-                <label class="block text-sm font-medium text-gray-700">Días de pago</label>
-                <input
-                    type="text"
-                    x-model="diasPago"
-                    placeholder="Ej. lunes, miércoles"
-                    class="mt-1 w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-                />
-                <p class="mt-1 text-xs text-gray-500">Indica los días habituales de cobro separados por comas.</p>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">Día de pago</label>
+                    <select
+                        x-model="diaPago"
+                        class="mt-1 w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                    >
+                        <option value="">Selecciona un día</option>
+                        <option value="Lunes">Lunes</option>
+                        <option value="Martes">Martes</option>
+                        <option value="Miércoles">Miércoles</option>
+                        <option value="Jueves">Jueves</option>
+                        <option value="Viernes">Viernes</option>
+                        <option value="Sábado">Sábado</option>
+                        <option value="Domingo">Domingo</option>
+                    </select>
+                    <p class="mt-1 text-xs text-gray-500">Elige el día habitual para realizar los cobros.</p>
+                </div>
+
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">Hora de pago</label>
+                    <input
+                        type="time"
+                        x-model="horaPago"
+                        class="mt-1 w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                    />
+                    <p class="mt-1 text-xs text-gray-500">Registra la hora (formato 24 hrs) en la que inicia la ruta.</p>
+                </div>
             </div>
 
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera.blade.php
@@ -66,10 +66,10 @@
                     <span class="text-sm font-semibold text-gray-900">
                       {{ $p->nombre }} {{ $p->apellido_p }} {{ $p->apellido_m }}
                     </span>
-                    @php $diasPago = trim((string) ($p->dias_de_pago ?? '')); @endphp
-                    @if($diasPago !== '')
-                      <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
-                    @endif
+                    @php $horarioPago = trim((string) ($p->horario_pago_resumen ?? '')); @endphp
+                      @if($horarioPago !== '')
+                      <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
+                      @endif
                   </div>
                 </div>
               </div>

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera_activa.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera_activa.blade.php
@@ -37,12 +37,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-indigo-100 text-indigo-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div class="flex flex-col">
                             <span class="text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera_falla.blade.php
@@ -14,12 +14,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-red-100 text-red-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera_inactiva.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera_inactiva.blade.php
@@ -12,12 +12,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-gray-200 text-gray-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile_legacy/supervisor/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/cartera_vencida.blade.php
@@ -16,12 +16,12 @@
                         <span class="inline-flex items-center justify-center w-7 h-7 text-[12px] font-bold rounded-full bg-orange-100 text-orange-700">
                             {{ $loop->iteration }}
                         </span>
-                        @php $diasPago = trim((string) data_get($promotor, 'dias_de_pago', '')); @endphp
+                        @php $horarioPago = trim((string) data_get($promotor, 'horario_pago', '')); @endphp
                         <div>
                             <span class="block text-[15px] font-semibold text-gray-900">{{ $promotor['nombre'] }}</span>
                             <span class="text-xs text-gray-500">Promotor</span>
-                            @if($diasPago !== '')
-                                <span class="text-[11px] text-gray-500">Días de pago: {{ $diasPago }}</span>
+                            @if($horarioPago !== '')
+                                <span class="text-[11px] text-gray-500">Horario de pago: {{ $horarioPago }}</span>
                             @endif
                         </div>
                     </div>

--- a/resources/views/mobile_legacy/supervisor/cartera/promotor.blade.php
+++ b/resources/views/mobile_legacy/supervisor/cartera/promotor.blade.php
@@ -3,10 +3,10 @@
     <section class="bg-white rounded-2xl shadow-lg ring-1 ring-gray-900/5 overflow-hidden">
       <div class="p-5">
         <h2 class="text-base font-bold text-gray-900 mb-3">{{ $promotor->nombre }} {{ $promotor->apellido_p }} {{ $promotor->apellido_m }}</h2>
-        @php $diasPago = trim((string) ($promotor->dias_de_pago ?? '')); @endphp
-        @if($diasPago !== '')
-          <p class="text-xs text-gray-500 mb-4">Días de pago: {{ $diasPago }}</p>
-        @endif
+        @php $horarioPago = trim((string) ($promotor->horario_pago_resumen ?? '')); @endphp
+          @if($horarioPago !== '')
+            <p class="text-xs text-gray-500 mb-4">Horario de pago: {{ $horarioPago }}</p>
+          @endif
         <div class="space-y-3">
           @forelse($clientes as $c)
             <a href="{{ route('mobile.supervisor.cliente_historial', $c->id) }}" class="block rounded-xl border border-gray-100 p-3 shadow-md hover:shadow transition">

--- a/resources/views/mobile_legacy/supervisor/venta/horarios.blade.php
+++ b/resources/views/mobile_legacy/supervisor/venta/horarios.blade.php
@@ -79,9 +79,9 @@
                   {{ trim(($p->nombre ?? '').' '.($p->apellido_p ?? '').' '.($p->apellido_m ?? '')) ?: ($p->nombre_completo ?? '—') }}
                 </span>
               </div>
-              @php $diasPago = trim((string) ($p->dias_de_pago ?? '')); @endphp
-              @if($diasPago !== '')
-                <p class="ml-8 text-xs text-gray-500">Días de pago: {{ $diasPago }}</p>
+              @php $horarioPago = trim((string) ($p->horario_pago_resumen ?? '')); @endphp
+              @if($horarioPago !== '')
+                <p class="ml-8 text-xs text-gray-500">Horario de pago: {{ $horarioPago }}</p>
               @endif
             </div>
             {!! $btn($definirRoute($p->id ?? 0), 'Definir', 'indigo', 'sm') !!}

--- a/tests/Feature/PromotorObjetivoTest.php
+++ b/tests/Feature/PromotorObjetivoTest.php
@@ -136,7 +136,8 @@ function createPromotorContext(array $promotorOverrides = []): array
         'colonia' => 'Centro',
         'venta_proyectada_objetivo' => 10000,
         'bono' => 1000,
-        'dias_de_pago' => 'lunes, miércoles',
+        'dia_de_pago' => 'Lunes',
+        'hora_de_pago' => '09:30',
     ], $promotorOverrides));
 
     return [$promotorUser, $promotor];

--- a/tests/Feature/SupervisorCarteraTest.php
+++ b/tests/Feature/SupervisorCarteraTest.php
@@ -171,6 +171,8 @@ function createPromotorParaSupervisorCartera(Supervisor $supervisor, array $over
         'venta_proyectada_objetivo' => 20000,
         'colonia' => 'Centro',
         'bono' => 0,
+        'dia_de_pago' => 'Lunes',
+        'hora_de_pago' => '09:30',
         'creado_en' => now(),
         'actualizado_en' => now(),
     ], $overrides));
@@ -188,6 +190,7 @@ function createClienteParaSupervisorCartera(Promotor $promotor, string $curp, st
         'tiene_credito_activo' => true,
         'cartera_estado' => 'activo',
         'monto_maximo' => 15000,
+        'horario_de_pago' => '10:00',
         'creado_en' => now(),
         'actualizado_en' => now(),
         'activo' => true,

--- a/tests/Feature/SupervisorObjetivoTest.php
+++ b/tests/Feature/SupervisorObjetivoTest.php
@@ -187,6 +187,8 @@ function createPromotorParaSupervisorObjetivo(Supervisor $supervisor, array $ove
         'venta_proyectada_objetivo' => 10000,
         'colonia' => 'Centro',
         'bono' => 0,
+        'dia_de_pago' => 'Lunes',
+        'hora_de_pago' => '09:30',
         'creado_en' => now(),
         'actualizado_en' => now(),
     ], $overrides));
@@ -204,6 +206,7 @@ function createClienteParaSupervisorObjetivo(Promotor $promotor, string $curp, s
         'tiene_credito_activo' => true,
         'cartera_estado' => 'activo',
         'monto_maximo' => 15000,
+        'horario_de_pago' => '10:00',
         'creado_en' => now(),
         'actualizado_en' => now(),
         'activo' => true,


### PR DESCRIPTION
## Summary
- add a migration and model casting to replace `dias_de_pago` with `dia_de_pago`/`hora_de_pago`
- update seeders, controllers, and tests to populate and read the new payment schedule fields
- refresh mobile and legacy supervisor/ejecutivo views to display and edit the schedule with day and time inputs

## Testing
- `php artisan test` *(fails: Vite manifest not found for guest/app layouts)*

------
https://chatgpt.com/codex/tasks/task_e_68d476b25e048325b673712f67e7bdd1