### PR TITLE
Ajusta búsqueda de supervisor y control de detalles

### DIFF
--- a/resources/views/mobile/supervisor/busqueda/busqueda.blade.php
+++ b/resources/views/mobile/supervisor/busqueda/busqueda.blade.php
@@ -24,50 +24,53 @@
 
         @if($query !== '')
             <div class="space-y-4">
-                @if(!$puedeBuscar)
-                    <p class="text-sm text-gray-500">No hay promotores asociados al supervisor seleccionado.</p>
+                @if(!$resultados || $totalResultados === 0)
+                    <p class="text-center text-gray-500">No se encontraron resultados.</p>
                 @else
                     <p class="text-sm text-gray-500">
-                        Se encontraron <span class="font-semibold text-gray-700">{{ $resultados->count() }}</span> coincidencias para "{{ $query }}".
+                        Se encontraron <span class="font-semibold text-gray-700">{{ $totalResultados }}</span> coincidencias para "{{ $query }}".
                     </p>
 
-                    @if($resultados->isEmpty())
-                        <p class="text-center text-gray-500">No se encontraron resultados.</p>
-                    @else
-                        <div class="space-y-3">
-                            @foreach($resultados as $resultado)
-                                @php $detailEnabled = (bool) ($resultado['puede_detallar'] ?? false); @endphp
-                                <div x-data="{ detail: false }" class="border border-gray-200 rounded-xl shadow-sm">
-                                    <div class="flex items-start justify-between gap-3 p-3">
-                                        <div class="min-w-0 space-y-1">
-                                            <p class="text-sm font-semibold text-gray-900">{{ $resultado['nombre'] }}</p>
-                                            <p class="text-xs text-gray-600">
-                                                Estatus del crédito: <span class="font-semibold text-gray-800">{{ $resultado['estatus_credito'] }}</span>
-                                            </p>
+                    <div class="space-y-3">
+                        @foreach($resultados as $resultado)
+                            @php $detailEnabled = (bool) ($resultado['puede_detallar'] ?? false); @endphp
+                            <div x-data="{ detail: false }" class="border border-gray-200 rounded-xl shadow-sm">
+                                <div class="flex items-start justify-between gap-3 p-3">
+                                    <div class="min-w-0 space-y-1">
+                                        <p class="text-sm font-semibold text-gray-900">{{ $resultado['nombre'] }}</p>
+                                        <p class="text-xs text-gray-600">
+                                            Estatus del crédito: <span class="font-semibold text-gray-800">{{ $resultado['estatus_credito'] }}</span>
+                                        </p>
+                                        <p class="text-[11px] text-gray-500">
+                                            Promotor: <span class="font-semibold text-gray-700">{{ $resultado['promotor'] }}</span>
+                                        </p>
+
+                                        @if($detailEnabled)
                                             <p class="text-xs text-gray-600">
                                                 Supervisor: <span class="font-semibold text-gray-800">{{ $resultado['supervisor'] }}</span>
                                             </p>
-                                            <p class="text-xs text-gray-600">
-                                                Aval: <span class="font-semibold text-gray-800">{{ $resultado['aval'] }}</span>
-                                            </p>
-                                            <p class="text-[11px] text-gray-500">
-                                                Promotor: <span class="font-semibold text-gray-700">{{ $resultado['promotor'] }}</span>
-                                            </p>
-                                        </div>
-                                        <div class="flex flex-col items-end gap-2">
-                                            <button
-                                                type="button"
-                                                @click="detail = true"
-                                                class="px-3 py-1 text-sm font-semibold rounded-lg shadow-sm transition
-                                                    {{ $detailEnabled ? 'bg-blue-600 text-white hover:bg-blue-700' : 'bg-gray-200 text-gray-500 cursor-not-allowed' }}"
-                                                {{ $detailEnabled ? '' : 'disabled' }}
-                                            >Detalles</button>
-                                            @unless($detailEnabled)
-                                                <p class="text-[11px] font-medium text-red-500">Asignado a otro supervisor</p>
-                                            @endunless
-                                        </div>
+                                            @if(!empty($resultado['aval'] ?? null))
+                                                <p class="text-xs text-gray-600">
+                                                    Aval: <span class="font-semibold text-gray-800">{{ $resultado['aval'] }}</span>
+                                                </p>
+                                            @endif
+                                        @endif
                                     </div>
+                                    <div class="flex flex-col items-end gap-2">
+                                        <button
+                                            type="button"
+                                            @click="detail = true"
+                                            class="px-3 py-1 text-sm font-semibold rounded-lg shadow-sm transition
+                                                {{ $detailEnabled ? 'bg-blue-600 text-white hover:bg-blue-700' : 'bg-gray-200 text-gray-500 cursor-not-allowed' }}"
+                                            {{ $detailEnabled ? '' : 'disabled' }}
+                                        >Detalles</button>
+                                        @unless($detailEnabled)
+                                            <p class="text-[11px] font-medium text-red-500">Asignado a otro supervisor</p>
+                                        @endunless
+                                    </div>
+                                </div>
 
+                                @if($detailEnabled && !empty($resultado['detalle']))
                                     <div x-show="detail" x-cloak @click.self="detail = false" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
                                         <div class="relative w-full max-w-md bg-white rounded-2xl shadow-xl p-5 space-y-4">
                                             <button
@@ -168,8 +171,14 @@
                                             </div>
                                         </div>
                                     </div>
-                                </div>
-                            @endforeach
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+
+                    @if($resultados->hasPages())
+                        <div class="pt-2">
+                            {{ $resultados->links('pagination::tailwind') }}
                         </div>
                     @endif
                 @endif

--- a/resources/views/mobile_legacy/supervisor/busqueda/busqueda.blade.php
+++ b/resources/views/mobile_legacy/supervisor/busqueda/busqueda.blade.php
@@ -92,60 +92,76 @@
                 <h2 class="text-lg font-bold text-gray-900">Clientes</h2>
                 <div class="space-y-2">
                     @foreach($clientes as $r)
+                        @php $detailEnabled = (bool) ($r['puede_detallar'] ?? true); @endphp
                         <div x-data="{ open: false, detail: false }" class="border border-gray-200 rounded">
                             <div class="flex items-center justify-between p-2 cursor-pointer" @click="open = !open">
                                 <p class="font-semibold text-gray-800">{{ $r['nombre'] }}</p>
-                                <a href="#" @click.stop="detail = true" class="px-3 py-1 text-sm font-semibold text-white bg-blue-600 rounded">D</a>
+                                <div class="flex items-center gap-2">
+                                    <button
+                                        type="button"
+                                        @click.stop="detail = true"
+                                        class="px-3 py-1 text-sm font-semibold rounded {{ $detailEnabled ? 'text-white bg-blue-600' : 'bg-gray-200 text-gray-500 cursor-not-allowed' }}"
+                                        {{ $detailEnabled ? '' : 'disabled' }}
+                                    >D</button>
+                                    @unless($detailEnabled)
+                                        <span class="text-[11px] font-medium text-red-500">Asignado a otro supervisor</span>
+                                    @endunless
+                                </div>
                             </div>
                             <div x-show="open" x-cloak class="p-2 text-sm text-gray-700 space-y-1">
-                                <p><span class="font-semibold">Domicilio:</span> {{ $r['domicilio'] }}</p>
                                 <p><span class="font-semibold">Promotor:</span> {{ $r['promotor']['nombre'] }}</p>
-                                <p><span class="font-semibold">Tipo de crédito:</span> {{ ucfirst($r['tipo_credito']) }}</p>
-                                <p><span class="font-semibold">Cantidad:</span> ${{ number_format($r['monto_credito'], 2) }}</p>
-                                <p><span class="font-semibold">Fecha:</span> {{ $r['fecha_creacion'] }}</p>
+                                <p><span class="font-semibold">Estatus:</span> {{ ucfirst($r['tipo_credito']) }}</p>
+
+                                @if($detailEnabled)
+                                    <p><span class="font-semibold">Domicilio:</span> {{ $r['domicilio'] }}</p>
+                                    <p><span class="font-semibold">Cantidad:</span> ${{ number_format($r['monto_credito'], 2) }}</p>
+                                    <p><span class="font-semibold">Fecha:</span> {{ $r['fecha_creacion'] }}</p>
+                                @endif
                             </div>
 
-                            <div x-show="detail" x-cloak @click.self="detail = false" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-                                <div class="bg-white rounded-lg p-4 w-full max-w-md relative">
+                            @if($detailEnabled)
+                                <div x-show="detail" x-cloak @click.self="detail = false" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+                                    <div class="bg-white rounded-lg p-4 w-full max-w-md relative">
                                     <button class="absolute top-2 right-2 text-gray-500" @click="detail = false">✕</button>
-                                    <h2 class="text-lg font-bold mb-2">{{ $r['nombre'] }}</h2>
-                                    <p class="text-sm mb-1"><span class="font-semibold">Teléfono:</span> {{ $r['telefono'] }}</p>
-                                    <p class="text-sm mb-1"><span class="font-semibold">Domicilio:</span> {{ $r['domicilio'] }}</p>
-                                    <p class="text-sm mb-2">
-                                        <span class="font-semibold">Status:</span>
-                                        @if($r['status'] === 'activo_con_deuda')
-                                            Activo con deuda: ${{ number_format($r['deuda'], 2) }}
-                                        @elseif($r['status'] === 'activo_sin_deuda')
-                                            Activo sin deuda
-                                        @elseif($r['status'] === 'liquidado')
-                                            Liquidado
-                                        @elseif($r['status'] === 'deudor')
-                                            Deudor: ${{ number_format($r['deuda_interes'], 2) }}
-                                        @endif
-                                    </p>
-                                    <div class="grid grid-cols-2 gap-2 mb-2">
-                                        @foreach($r['fotos'] as $foto)
-                                            <img src="{{ $foto }}" alt="Foto del cliente" class="rounded" />
-                                        @endforeach
-                                        <img src="{{ $r['garantia'] }}" alt="Foto de la garantía" class="rounded col-span-2" />
-                                    </div>
-                                    <div class="text-sm space-y-2">
-                                        <div>
-                                            <p class="font-semibold">Aval</p>
-                                            <p>{{ $r['aval']['nombre'] }}</p>
-                                            <p>{{ $r['aval']['telefono'] }}</p>
-                                            <p>{{ $r['aval']['domicilio'] }}</p>
+                                        <h2 class="text-lg font-bold mb-2">{{ $r['nombre'] }}</h2>
+                                        <p class="text-sm mb-1"><span class="font-semibold">Teléfono:</span> {{ $r['telefono'] }}</p>
+                                        <p class="text-sm mb-1"><span class="font-semibold">Domicilio:</span> {{ $r['domicilio'] }}</p>
+                                        <p class="text-sm mb-2">
+                                            <span class="font-semibold">Status:</span>
+                                            @if($r['status'] === 'activo_con_deuda')
+                                                Activo con deuda: ${{ number_format($r['deuda'], 2) }}
+                                            @elseif($r['status'] === 'activo_sin_deuda')
+                                                Activo sin deuda
+                                            @elseif($r['status'] === 'liquidado')
+                                                Liquidado
+                                            @elseif($r['status'] === 'deudor')
+                                                Deudor: ${{ number_format($r['deuda_interes'], 2) }}
+                                            @endif
+                                        </p>
+                                        <div class="grid grid-cols-2 gap-2 mb-2">
+                                            @foreach($r['fotos'] as $foto)
+                                                <img src="{{ $foto }}" alt="Foto del cliente" class="rounded" />
+                                            @endforeach
+                                            <img src="{{ $r['garantia'] }}" alt="Foto de la garantía" class="rounded col-span-2" />
                                         </div>
-                                        <div>
-                                            <p class="font-semibold">Promotor</p>
-                                            <p>{{ $r['promotor']['nombre'] }}</p>
-                                            <p>{{ $r['promotor']['email'] }}</p>
-                                            <p>{{ $r['promotor']['telefono'] }}</p>
-                                            <p>{{ $r['promotor']['domicilio'] }}</p>
+                                        <div class="text-sm space-y-2">
+                                            <div>
+                                                <p class="font-semibold">Aval</p>
+                                                <p>{{ $r['aval']['nombre'] }}</p>
+                                                <p>{{ $r['aval']['telefono'] }}</p>
+                                                <p>{{ $r['aval']['domicilio'] }}</p>
+                                            </div>
+                                            <div>
+                                                <p class="font-semibold">Promotor</p>
+                                                <p>{{ $r['promotor']['nombre'] }}</p>
+                                                <p>{{ $r['promotor']['email'] }}</p>
+                                                <p>{{ $r['promotor']['telefono'] }}</p>
+                                                <p>{{ $r['promotor']['domicilio'] }}</p>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
+                            @endif
                         </div>
                     @endforeach
                 </div>


### PR DESCRIPTION
## Summary
- remove the promotor filter from the supervisor search, add pagination, and surface the total results count
- ensure the search mapping only exposes detailed contact data when the client belongs to the acting supervisor
- update the mobile and legacy search views to hide sensitive data and keep the detail button disabled for out-of-scope clients

## Testing
- vendor/bin/phpunit *(fails: binary not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d47b577ec08325906d3cc26773627b