### PR TITLE
feat(ejecutivo): agregar detalle de cartera y pruebas de acceso

### DIFF
--- a/app/Http/Controllers/EjecutivoController.php
+++ b/app/Http/Controllers/EjecutivoController.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Concerns\HandlesSupervisorContext;
 use App\Models\Cliente;
 use App\Models\Credito;
 use App\Models\Ejecutivo;
+use App\Models\Ejercicio;
 use App\Models\Promotor;
 use App\Models\Supervisor;
 use App\Services\BusquedaClientesService;
@@ -12,6 +13,7 @@ use App\Support\RoleHierarchy;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Route;
 
 class EjecutivoController extends Controller
 {
@@ -187,6 +189,504 @@ class EjecutivoController extends Controller
             'cartera_falla',
             'cartera_inactivaP'
         ));
+    }
+
+    public function cartera_activa(Request $request)
+    {
+        $user = $request->user();
+        $primaryRole = RoleHierarchy::resolvePrimaryRole($user);
+
+        $this->resolveEjecutivoContext($primaryRole, $user?->id, (int) $request->query('ejecutivo_id'));
+
+        $supervisor = $this->resolveSupervisorContext($request);
+
+        if (!$supervisor) {
+            $message = $primaryRole === 'ejecutivo'
+                ? 'Perfil de ejecutivo sin supervisores configurados.'
+                : 'Supervisor fuera de tu alcance.';
+
+            abort(403, $message);
+        }
+
+        $promotoresPaginator = Promotor::where('supervisor_id', $supervisor->id)
+            ->select('id', 'nombre', 'apellido_p', 'apellido_m', 'dias_de_pago')
+            ->orderBy('nombre')
+            ->orderBy('apellido_p')
+            ->orderBy('apellido_m')
+            ->paginate(5);
+
+        $blocks = collect($promotoresPaginator->items())->map(function (Promotor $promotor) {
+            $clientes = Cliente::where('promotor_id', $promotor->id)
+                ->whereHas('credito', fn ($query) => $query->where('estado', 'activo'))
+                ->with([
+                    'credito.pagosProyectados.pagosReales.pagoCompleto',
+                    'credito.pagosProyectados.pagosReales.pagoAnticipo',
+                    'credito.pagosProyectados.pagosReales.pagoDiferido',
+                ])
+                ->get();
+
+            $dinero = 0.0;
+
+            $items = $clientes->map(function (Cliente $cliente) use (&$dinero) {
+                $credito = $cliente->credito;
+
+                if (!$credito) {
+                    return null;
+                }
+
+                $dinero += (float) ($credito->monto_total ?? 0);
+
+                $pagos = $credito->pagosProyectados ?? collect();
+                $pagos = $pagos instanceof Collection ? $pagos : collect($pagos);
+
+                $totalWeeks = $pagos->count();
+                $fechaInicio = $credito->fecha_inicio ? Carbon::parse($credito->fecha_inicio) : null;
+                $currentWeek = ($totalWeeks > 0 && $fechaInicio)
+                    ? min(now()->diffInWeeks($fechaInicio) + 1, $totalWeeks)
+                    : 0;
+
+                $pago = $pagos->firstWhere('semana', $currentWeek);
+                $pagoSemanal = (float) ($pago->monto_proyectado ?? 0);
+                $status = '!';
+
+                if ($pago) {
+                    $fechaLimite = $pago->fecha_limite ? Carbon::parse($pago->fecha_limite) : null;
+                    $primerPago = $pago->pagosReales instanceof Collection
+                        ? $pago->pagosReales->sortBy('fecha_pago')->first()
+                        : null;
+
+                    if ($primerPago && $fechaLimite) {
+                        $fechaPago = Carbon::parse($primerPago->fecha_pago);
+
+                        if ($fechaPago->lt($fechaLimite)) {
+                            $status = 'Ad';
+                        } elseif ($fechaPago->equalTo($fechaLimite)) {
+                            $status = 'V';
+                        } else {
+                            $status = 'F';
+                        }
+                    } elseif ($fechaLimite) {
+                        $status = $fechaLimite->isPast() ? 'F' : '!';
+                    }
+                }
+
+                return [
+                    'id' => $cliente->id,
+                    'nombre' => trim(collect([
+                        $cliente->nombre,
+                        $cliente->apellido_p,
+                        $cliente->apellido_m,
+                    ])->filter()->implode(' ')),
+                    'monto' => (float) ($credito->monto_total ?? 0),
+                    'semana' => $currentWeek,
+                    'pago_semanal' => $pagoSemanal,
+                    'status' => $status,
+                ];
+            })->filter()->values();
+
+            return [
+                'nombre' => trim(collect([
+                    $promotor->nombre,
+                    $promotor->apellido_p,
+                    $promotor->apellido_m,
+                ])->filter()->implode(' ')),
+                'dias_de_pago' => trim((string) ($promotor->dias_de_pago ?? '')),
+                'dinero' => $dinero,
+                'clientes' => $items,
+            ];
+        });
+
+        $supervisorContextQuery = $request->attributes->get('supervisor_context_query', []);
+
+        return view('mobile.ejecutivo.cartera.cartera_activa', [
+            'blocks' => $blocks,
+            'promotoresPaginator' => $promotoresPaginator,
+            'role' => $primaryRole,
+            'supervisorContextQuery' => $supervisorContextQuery,
+        ]);
+    }
+
+    public function cartera_vencida(Request $request)
+    {
+        $user = $request->user();
+        $primaryRole = RoleHierarchy::resolvePrimaryRole($user);
+
+        $this->resolveEjecutivoContext($primaryRole, $user?->id, (int) $request->query('ejecutivo_id'));
+
+        $supervisor = $this->resolveSupervisorContext($request);
+
+        if (!$supervisor) {
+            $message = $primaryRole === 'ejecutivo'
+                ? 'Perfil de ejecutivo sin supervisores configurados.'
+                : 'Supervisor fuera de tu alcance.';
+
+            abort(403, $message);
+        }
+
+        $promotoresPaginator = Promotor::where('supervisor_id', $supervisor->id)
+            ->select('id', 'nombre', 'apellido_p', 'apellido_m', 'dias_de_pago')
+            ->orderBy('nombre')
+            ->orderBy('apellido_p')
+            ->orderBy('apellido_m')
+            ->paginate(5);
+
+        $blocks = collect($promotoresPaginator->items())->map(function (Promotor $promotor) {
+            $clientes = Cliente::where('promotor_id', $promotor->id)
+                ->whereHas('credito', fn ($query) => $query->where('estado', 'vencido'))
+                ->with([
+                    'credito.pagosProyectados.pagosReales.pagoCompleto',
+                    'credito.pagosProyectados.pagosReales.pagoAnticipo',
+                    'credito.pagosProyectados.pagosReales.pagoDiferido',
+                ])
+                ->get();
+
+            $items = collect();
+            $dineroVencido = 0.0;
+            $baseCreditos = 0.0;
+
+            foreach ($clientes as $cliente) {
+                $credito = $cliente->credito;
+
+                if (!$credito) {
+                    continue;
+                }
+
+                $pagos = $credito->pagosProyectados instanceof Collection
+                    ? $credito->pagosProyectados
+                    : collect($credito->pagosProyectados);
+
+                $pagado = (float) $pagos->flatMap(function ($pago) {
+                    return $pago->pagosReales instanceof Collection
+                        ? $pago->pagosReales
+                        : collect($pago->pagosReales);
+                })->sum(fn ($pago) => (float) ($pago->monto ?? 0));
+
+                $proyectado = (float) $pagos->sum(function ($pago) {
+                    return (float) ($pago->monto_proyectado ?? 0);
+                });
+
+                $baseCreditos += (float) ($credito->monto_total ?? 0);
+                $deficit = max(0.0, $proyectado - $pagado);
+
+                if ($deficit > 0) {
+                    $dineroVencido += $deficit;
+                    $estatus = $pagado <= 0 ? 'total' : 'parcial';
+
+                    $items->push([
+                        'id' => $cliente->id,
+                        'nombre' => trim(collect([
+                            $cliente->nombre,
+                            $cliente->apellido_p,
+                            $cliente->apellido_m,
+                        ])->filter()->implode(' ')),
+                        'monto' => $deficit,
+                        'estatus' => $estatus,
+                    ]);
+                }
+            }
+
+            $porcentajeVencido = $baseCreditos > 0
+                ? round(($dineroVencido / max(1e-6, $baseCreditos)) * 100)
+                : 0;
+
+            return [
+                'nombre' => trim(collect([
+                    $promotor->nombre,
+                    $promotor->apellido_p,
+                    $promotor->apellido_m,
+                ])->filter()->implode(' ')),
+                'dias_de_pago' => trim((string) ($promotor->dias_de_pago ?? '')),
+                'dinero' => $dineroVencido,
+                'vencido' => $porcentajeVencido,
+                'clientes' => $items->values(),
+            ];
+        });
+
+        $supervisorContextQuery = $request->attributes->get('supervisor_context_query', []);
+
+        return view('mobile.ejecutivo.cartera.cartera_vencida', [
+            'blocks' => $blocks,
+            'promotoresPaginator' => $promotoresPaginator,
+            'role' => $primaryRole,
+            'supervisorContextQuery' => $supervisorContextQuery,
+        ]);
+    }
+
+    public function cartera_inactiva(Request $request)
+    {
+        $user = $request->user();
+        $primaryRole = RoleHierarchy::resolvePrimaryRole($user);
+
+        $this->resolveEjecutivoContext($primaryRole, $user?->id, (int) $request->query('ejecutivo_id'));
+
+        $supervisor = $this->resolveSupervisorContext($request);
+
+        if (!$supervisor) {
+            $message = $primaryRole === 'ejecutivo'
+                ? 'Perfil de ejecutivo sin supervisores configurados.'
+                : 'Supervisor fuera de tu alcance.';
+
+            abort(403, $message);
+        }
+
+        $promotoresPaginator = Promotor::where('supervisor_id', $supervisor->id)
+            ->select('id', 'nombre', 'apellido_p', 'apellido_m', 'dias_de_pago')
+            ->orderBy('nombre')
+            ->orderBy('apellido_p')
+            ->orderBy('apellido_m')
+            ->paginate(5);
+
+        $blocks = collect($promotoresPaginator->items())->map(function (Promotor $promotor) {
+            $clientes = Cliente::where('promotor_id', $promotor->id)
+                ->where(function ($query) {
+                    $query->where('activo', false)->orWhereNull('activo');
+                })
+                ->with([
+                    'credito.pagosProyectados.pagosReales.pagoCompleto',
+                    'credito.pagosProyectados.pagosReales.pagoAnticipo',
+                    'credito.pagosProyectados.pagosReales.pagoDiferido',
+                    'credito.datoContacto',
+                ])
+                ->get();
+
+            $items = $clientes->map(function (Cliente $cliente) {
+                $credito = $cliente->credito;
+                $dato = $credito?->datoContacto;
+
+                $pagos = $credito?->pagosProyectados instanceof Collection
+                    ? $credito->pagosProyectados
+                    : collect($credito?->pagosProyectados);
+
+                $vencidos = $pagos->filter(function ($pago) {
+                    if (!$pago->fecha_limite) {
+                        return false;
+                    }
+
+                    $fecha = $pago->fecha_limite instanceof Carbon
+                        ? $pago->fecha_limite
+                        : Carbon::parse($pago->fecha_limite);
+
+                    return $fecha->isPast();
+                });
+
+                $proyectado = (float) $vencidos->sum(fn ($pago) => (float) ($pago->monto_proyectado ?? 0));
+                $pagado = (float) $vencidos->flatMap(function ($pago) {
+                    return $pago->pagosReales instanceof Collection
+                        ? $pago->pagosReales
+                        : collect($pago->pagosReales);
+                })->sum(fn ($pago) => (float) ($pago->monto ?? 0));
+
+                $direccion = $dato ? collect([
+                    trim(($dato->calle ?? '') . ' ' . ($dato->numero_ext ?? '')),
+                    $dato->numero_int ? 'Int. ' . $dato->numero_int : null,
+                    $dato->colonia ?? null,
+                    $dato->municipio ?? null,
+                    $dato->estado ?? null,
+                    $dato->cp ? 'CP ' . $dato->cp : null,
+                ])->filter()->implode(', ') : null;
+
+                return [
+                    'nombre' => trim(collect([
+                        $cliente->nombre,
+                        $cliente->apellido_p,
+                        $cliente->apellido_m,
+                    ])->filter()->implode(' ')),
+                    'curp' => $cliente->CURP,
+                    'fecha_nac' => $cliente->fecha_nacimiento
+                        ? Carbon::parse($cliente->fecha_nacimiento)->format('Y-m-d')
+                        : null,
+                    'direccion' => $direccion,
+                    'ultimo_credito' => $credito?->fecha_inicio
+                        ? Carbon::parse($credito->fecha_inicio)->format('Y-m-d')
+                        : null,
+                    'monto_credito' => $credito?->monto_total ? (float) $credito->monto_total : 0.0,
+                    'telefono' => $dato->tel_cel ?? $dato->tel_fijo ?? null,
+                    'fallas' => $proyectado > $pagado
+                        ? $vencidos->count()
+                        : 0,
+                ];
+            })->values();
+
+            return [
+                'nombre' => trim(collect([
+                    $promotor->nombre,
+                    $promotor->apellido_p,
+                    $promotor->apellido_m,
+                ])->filter()->implode(' ')),
+                'dias_de_pago' => trim((string) ($promotor->dias_de_pago ?? '')),
+                'clientes' => $items,
+            ];
+        });
+
+        $supervisorContextQuery = $request->attributes->get('supervisor_context_query', []);
+
+        return view('mobile.ejecutivo.cartera.cartera_inactiva', [
+            'blocks' => $blocks,
+            'promotoresPaginator' => $promotoresPaginator,
+            'role' => $primaryRole,
+            'supervisorContextQuery' => $supervisorContextQuery,
+        ]);
+    }
+
+    public function cartera_falla(Request $request)
+    {
+        $user = $request->user();
+        $primaryRole = RoleHierarchy::resolvePrimaryRole($user);
+
+        $this->resolveEjecutivoContext($primaryRole, $user?->id, (int) $request->query('ejecutivo_id'));
+
+        $supervisor = $this->resolveSupervisorContext($request);
+
+        if (!$supervisor) {
+            $message = $primaryRole === 'ejecutivo'
+                ? 'Perfil de ejecutivo sin supervisores configurados.'
+                : 'Supervisor fuera de tu alcance.';
+
+            abort(403, $message);
+        }
+
+        $promotoresPaginator = Promotor::where('supervisor_id', $supervisor->id)
+            ->select('id', 'nombre', 'apellido_p', 'apellido_m', 'dias_de_pago')
+            ->orderBy('nombre')
+            ->orderBy('apellido_p')
+            ->orderBy('apellido_m')
+            ->paginate(5);
+
+        $blocks = collect($promotoresPaginator->items())->map(function (Promotor $promotor) {
+            $clientes = Cliente::where('promotor_id', $promotor->id)
+                ->with([
+                    'credito.pagosProyectados.pagosReales.pagoCompleto',
+                    'credito.pagosProyectados.pagosReales.pagoAnticipo',
+                    'credito.pagosProyectados.pagosReales.pagoDiferido',
+                ])
+                ->get();
+
+            $items = collect();
+            $dineroFalla = 0.0;
+            $baseCreditos = 0.0;
+
+            foreach ($clientes as $cliente) {
+                $credito = $cliente->credito;
+
+                if (!$credito) {
+                    continue;
+                }
+
+                $pagos = $credito->pagosProyectados instanceof Collection
+                    ? $credito->pagosProyectados
+                    : collect($credito->pagosProyectados);
+
+                $pagado = (float) $pagos->flatMap(function ($pago) {
+                    return $pago->pagosReales instanceof Collection
+                        ? $pago->pagosReales
+                        : collect($pago->pagosReales);
+                })->sum(fn ($pago) => (float) ($pago->monto ?? 0));
+
+                $proyectado = (float) $pagos->sum(function ($pago) {
+                    return (float) ($pago->monto_proyectado ?? 0);
+                });
+
+                $baseCreditos += (float) ($credito->monto_total ?? 0);
+                $deficit = max(0.0, $proyectado - $pagado);
+
+                if ($deficit <= 0) {
+                    continue;
+                }
+
+                $dineroFalla += $deficit;
+
+                $items->push([
+                    'id' => $cliente->id,
+                    'nombre' => trim(collect([
+                        $cliente->nombre,
+                        $cliente->apellido_p,
+                        $cliente->apellido_m,
+                    ])->filter()->implode(' ')),
+                    'monto' => $deficit,
+                ]);
+            }
+
+            $porcentajeFalla = $baseCreditos > 0
+                ? round(($dineroFalla / max(1e-6, $baseCreditos)) * 100)
+                : 0;
+
+            return [
+                'nombre' => trim(collect([
+                    $promotor->nombre,
+                    $promotor->apellido_p,
+                    $promotor->apellido_m,
+                ])->filter()->implode(' ')),
+                'dias_de_pago' => trim((string) ($promotor->dias_de_pago ?? '')),
+                'dinero' => $dineroFalla,
+                'falla' => $porcentajeFalla,
+                'clientes' => $items->values(),
+            ];
+        });
+
+        $supervisorContextQuery = $request->attributes->get('supervisor_context_query', []);
+
+        return view('mobile.ejecutivo.cartera.cartera_falla', [
+            'blocks' => $blocks,
+            'promotoresPaginator' => $promotoresPaginator,
+            'role' => $primaryRole,
+            'supervisorContextQuery' => $supervisorContextQuery,
+        ]);
+    }
+
+    public function horarios(Request $request)
+    {
+        $user = $request->user();
+        $primaryRole = RoleHierarchy::resolvePrimaryRole($user);
+
+        $ejecutivo = $this->resolveEjecutivoContext($primaryRole, $user?->id, (int) $request->query('ejecutivo_id'));
+
+        if ($primaryRole === 'ejecutivo') {
+            abort_if(!$ejecutivo, 403, 'Perfil de ejecutivo no configurado.');
+        }
+
+        $supervisor = $this->resolveSupervisorContext($request, [
+            'promotores' => function ($query) {
+                $query->select('id', 'supervisor_id', 'nombre', 'apellido_p', 'apellido_m', 'dias_de_pago', 'venta_maxima', 'venta_proyectada_objetivo')
+                    ->orderBy('nombre')
+                    ->orderBy('apellido_p')
+                    ->orderBy('apellido_m');
+            },
+        ]);
+
+        $promotores = $supervisor?->promotores ?? collect();
+        $promotores = $promotores instanceof Collection ? $promotores : collect($promotores);
+
+        $promotores = $promotores->map(function (Promotor $promotor) {
+            $promotor->nombre_completo = trim(collect([
+                $promotor->nombre,
+                $promotor->apellido_p,
+                $promotor->apellido_m,
+            ])->filter()->implode(' '));
+
+            return $promotor;
+        })->values();
+
+        $ventaFecha = $supervisor?->id
+            ? Ejercicio::where('supervisor_id', $supervisor->id)
+                ->orderByDesc('fecha_inicio')
+                ->value('fecha_inicio')
+            : null;
+
+        $ventaFecha = $ventaFecha ? Carbon::parse($ventaFecha) : now();
+
+        $supervisorContextQuery = $request->attributes->get('supervisor_context_query', []);
+
+        $definirRoute = Route::has('mobile.supervisor.horarios.definir')
+            ? fn ($promotorId) => route('mobile.supervisor.horarios.definir', array_merge($supervisorContextQuery, ['promotor' => $promotorId]))
+            : fn ($promotorId = null) => '#';
+
+        return view('mobile.ejecutivo.venta.horarios', [
+            'venta_fecha' => $ventaFecha,
+            'promotores' => $promotores,
+            'definirRoute' => $definirRoute,
+            'role' => $primaryRole,
+            'supervisorContextQuery' => $supervisorContextQuery,
+        ]);
     }
 
     private function resolveEjecutivoContext(?string $primaryRole, ?int $userId, int $overrideEjecutivoId = 0): ?Ejecutivo

--- a/resources/views/mobile/ejecutivo/cartera/cartera_activa.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_activa.blade.php
@@ -1,6 +1,9 @@
 {{-- resources/views/mobile/supervisor/cartera/cartera_activa.blade.php --}}
 
 @php
+    $role = $role ?? 'ejecutivo';
+    $supervisorContextQuery = $supervisorContextQuery ?? [];
+
     // Helper para badge de estatus
     if (!function_exists('badgeClasses')) {
         function badgeClasses($s) {
@@ -117,7 +120,7 @@
             {{ $promotoresPaginator->withQueryString()->links() }}
         </div>
         {{-- <a href="{{ url()->previous() }}" --}}
-        <a href="{{ route("mobile.$role.cartera") }}"
+        <a href="{{ route("mobile.$role.cartera", array_merge($supervisorContextQuery, [])) }}"
         class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
             Regresar
         </a>

--- a/resources/views/mobile/ejecutivo/cartera/cartera_falla.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_falla.blade.php
@@ -1,5 +1,10 @@
 {{-- resources/views/mobile/supervisor/cartera/cartera_falla.blade.php --}}
 
+@php
+    $role = $role ?? 'ejecutivo';
+    $supervisorContextQuery = $supervisorContextQuery ?? [];
+@endphp
+
 <x-layouts.mobile.mobile-layout>
     
     <div x-data class="p-4 space-y-5">
@@ -52,7 +57,7 @@
                                 </button>
 
                                 {{-- Botón Historial --}}
-                                <a href='{{ route("mobile.$role.cliente_historial", $cliente["id"]) }}'
+                                <a href='{{ route("mobile.$role.cliente_historial", array_merge($supervisorContextQuery, ['cliente' => $cliente["id"]])) }}'
                                    class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white font-bold hover:bg-amber-600 shadow-sm">
                                     H
                                 </a>
@@ -67,7 +72,7 @@
             {{ $promotoresPaginator->withQueryString()->links() }}
         </div>
 
-        <a href="{{ url()->previous() }}"
+        <a href="{{ route("mobile.$role.cartera", array_merge($supervisorContextQuery, [])) }}"
           class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
           Regresar
         </a>

--- a/resources/views/mobile/ejecutivo/cartera/cartera_inactiva.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_inactiva.blade.php
@@ -1,5 +1,10 @@
 {{-- resources/views/mobile/supervisor/cartera/cartera_inactiva.blade.php --}}
 
+@php
+    $role = $role ?? 'ejecutivo';
+    $supervisorContextQuery = $supervisorContextQuery ?? [];
+@endphp
+
 <x-layouts.mobile.mobile-layout>
     <div x-data="{ showDetalle: null }" class="p-4 space-y-5">
         <h1 class="text-xl font-bold text-gray-900">Cartera Inactiva</h1>
@@ -74,7 +79,7 @@
         </div>
 
         {{-- Botón Regresar --}}
-        <a href="{{ url()->previous() }}"
+        <a href="{{ route("mobile.$role.cartera", array_merge($supervisorContextQuery, [])) }}"
           class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
           Regresar
         </a>

--- a/resources/views/mobile/ejecutivo/cartera/cartera_vencida.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera_vencida.blade.php
@@ -1,5 +1,10 @@
 {{-- resources/views/mobile/supervisor/cartera/cartera_vencida.blade.php --}}
 
+@php
+    $role = $role ?? 'ejecutivo';
+    $supervisorContextQuery = $supervisorContextQuery ?? [];
+@endphp
+
 <x-layouts.mobile.mobile-layout>
     <div x-data class="p-4 space-y-5">
         {{-- Incluimos el modal calculadora --}}
@@ -55,7 +60,7 @@
                                 </button>
 
                                 {{-- Botón Historial --}}
-                                <a href='{{ route("mobile.$role.cliente_historial", $cliente["id"]) }}'
+                                <a href='{{ route("mobile.$role.cliente_historial", array_merge($supervisorContextQuery, ['cliente' => $cliente["id"]])) }}'
                                    class="flex items-center justify-center w-8 h-8 rounded-lg bg-amber-500 text-white font-bold hover:bg-amber-600 shadow-sm"
                                    title="Historial">
                                     H
@@ -72,7 +77,7 @@
         </div>
 
         {{-- Botón Regresar --}}
-        <a href="{{ url()->previous() }}"
+        <a href="{{ route("mobile.$role.cartera", array_merge($supervisorContextQuery, [])) }}"
           class="flex items-center justify-center rounded-xl border border-gray-300 text-white text-sm font-semibold px-3 py-2 bg-blue-600 hover:bg-blue-700 shadow-sm">
           Regresar
         </a>

--- a/resources/views/mobile/ejecutivo/venta/horarios.blade.php
+++ b/resources/views/mobile/ejecutivo/venta/horarios.blade.php
@@ -1,12 +1,18 @@
 {{-- resources/views/mobile/supervisor/venta/definir_horarios.blade.php --}}
 @php
   use Carbon\Carbon;
+  use Illuminate\Support\Facades\Route;
 
   /** ===== Vars con defaults seguros ===== */
-  $role         = $role ?? 'supervisor';
+  $role         = $role ?? 'ejecutivo';
   $venta_fecha  = $venta_fecha ?? now();         // string|Carbon
-  $promotores   = $promotores ?? collect();      // colección de promotores
-  $definirRoute = fn($id) => route('mobile.supervisor.horarios.definir', $id); // ajusta si usas otra ruta
+  $supervisorContextQuery = $supervisorContextQuery ?? [];
+  $promotores   = $promotores instanceof \Illuminate\Support\Collection ? $promotores : collect($promotores ?? []);      // colección de promotores
+  $definirRoute = $definirRoute ?? function ($id) use ($supervisorContextQuery) {
+      return Route::has('mobile.supervisor.horarios.definir')
+          ? route('mobile.supervisor.horarios.definir', array_merge($supervisorContextQuery, ['promotor' => $id]))
+          : '#';
+  }; // ajusta si usas otra ruta
 
   /** ===== Normaliza fecha a DD/MM/YY ===== */
   try {
@@ -89,7 +95,7 @@
 
     {{-- ===== Botón Regresar (a mobile.index) ===== --}}
     <div class="pt-2">
-      <a href="{{ route('mobile.index') }}" class="inline-flex items-center justify-center rounded-xl font-semibold shadow text-sm px-3 py-2 border border-gray-300 bg-blue-600 text-white hover:bg-blue-700">
+      <a href="{{ route('mobile.'.$role.'.venta', array_merge($supervisorContextQuery, [])) }}" class="inline-flex items-center justify-center rounded-xl font-semibold shadow text-sm px-3 py-2 border border-gray-300 bg-blue-600 text-white hover:bg-blue-700">
         Regresar
       </a>
     </div>

--- a/tests/Feature/EjecutivoCarteraRoutesTest.php
+++ b/tests/Feature/EjecutivoCarteraRoutesTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use App\Models\Ejecutivo;
+use App\Models\Supervisor;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+$kanbanTestPath = dirname(__DIR__, 2) . '/database/kanban_test.sqlite';
+putenv('KANBAN_DB_DATABASE=' . $kanbanTestPath);
+$_ENV['KANBAN_DB_DATABASE'] = $kanbanTestPath;
+$_SERVER['KANBAN_DB_DATABASE'] = $kanbanTestPath;
+
+if (file_exists($kanbanTestPath)) {
+    unlink($kanbanTestPath);
+}
+
+if (!file_exists($kanbanTestPath)) {
+    touch($kanbanTestPath);
+}
+
+$envPath = dirname(__DIR__, 2) . '/.env';
+if (!file_exists($envPath)) {
+    file_put_contents($envPath, "");
+}
+
+beforeEach(function () {
+    global $kanbanTestPath;
+
+    config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+    $this->withoutVite();
+
+    if (file_exists($kanbanTestPath)) {
+        unlink($kanbanTestPath);
+    }
+
+    if (!file_exists($kanbanTestPath)) {
+        touch($kanbanTestPath);
+    }
+
+    Role::firstOrCreate(['name' => 'ejecutivo', 'guard_name' => 'web']);
+    Role::firstOrCreate(['name' => 'supervisor', 'guard_name' => 'web']);
+});
+
+it('permite al ejecutivo acceder a las vistas de cartera y horarios de sus supervisores', function () {
+    [$user, $supervisor] = createEjecutivoDetalleContext();
+
+    $routes = [
+        ['mobile.ejecutivo.cartera_activa', 'Cartera Activa'],
+        ['mobile.ejecutivo.cartera_falla', 'Cartera Falla'],
+        ['mobile.ejecutivo.cartera_vencida', 'Cartera Vencida'],
+        ['mobile.ejecutivo.cartera_inactiva', 'Cartera Inactiva'],
+        ['mobile.ejecutivo.horarios', 'Definir Horarios'],
+    ];
+
+    foreach ($routes as [$route, $text]) {
+        $this->actingAs($user)
+            ->get(route($route, ['supervisor' => $supervisor->id]))
+            ->assertOk()
+            ->assertSeeText($text);
+    }
+});
+
+it('restringe el acceso a las vistas de cartera cuando el supervisor no pertenece al ejecutivo', function () {
+    [$user, $supervisor] = createEjecutivoDetalleContext();
+
+    $otroSupervisor = createSupervisorForEjecutivo();
+
+    expect($otroSupervisor->id)->not()->toBe($supervisor->id);
+
+    $this->actingAs($user)
+        ->get(route('mobile.ejecutivo.cartera_activa', ['supervisor' => $otroSupervisor->id]))
+        ->assertForbidden();
+});
+
+/**
+ * @return array{0: User, 1: Supervisor}
+ */
+function createEjecutivoDetalleContext(): array
+{
+    $user = User::factory()->create(['rol' => 'ejecutivo']);
+    $user->assignRole('ejecutivo');
+
+    $ejecutivo = Ejecutivo::create([
+        'user_id' => $user->id,
+        'nombre' => 'Ernesto',
+        'apellido_p' => 'Pérez',
+        'apellido_m' => 'Salas',
+    ]);
+
+    $supervisor = createSupervisorForEjecutivo($ejecutivo);
+
+    return [$user, $supervisor];
+}
+
+function createSupervisorForEjecutivo(?Ejecutivo $ejecutivo = null): Supervisor
+{
+    if (!$ejecutivo) {
+        $ejecutivoUser = User::factory()->create(['rol' => 'ejecutivo']);
+        $ejecutivoUser->assignRole('ejecutivo');
+
+        $ejecutivo = Ejecutivo::create([
+            'user_id' => $ejecutivoUser->id,
+            'nombre' => 'Edgar',
+            'apellido_p' => 'Valdez',
+            'apellido_m' => 'Morales',
+        ]);
+    }
+
+    $supervisorUser = User::factory()->create(['rol' => 'supervisor']);
+    $supervisorUser->assignRole('supervisor');
+
+    return Supervisor::create([
+        'user_id' => $supervisorUser->id,
+        'ejecutivo_id' => $ejecutivo->id,
+        'nombre' => 'Silvia',
+        'apellido_p' => 'García',
+        'apellido_m' => 'Loera',
+    ]);
+}


### PR DESCRIPTION
## Summary
- agrega en EjecutivoController los métodos de detalle de cartera y horarios reutilizando la lógica de agrupación y el supervisorContextQuery
- actualiza las vistas móviles de cartera y horarios del ejecutivo para consumir los datos reales y mantener los parámetros de contexto
- incorpora pruebas de acceso que validan el comportamiento jerárquico en las rutas móviles de cartera y horarios

## Testing
- vendor/bin/pest --filter EjecutivoCarteraRoutesTest

------
https://chatgpt.com/codex/tasks/task_e_68d4f2c7e17c8325aef83c9cb3ecb23a