### PR TITLE
Allow executives to select supervisors in search context

### DIFF
--- a/app/Http/Controllers/EjecutivoController.php
+++ b/app/Http/Controllers/EjecutivoController.php
@@ -979,33 +979,6 @@ class EjecutivoController extends Controller
         return view('mobile.ejecutivo.informes.reportes');
     }
 
-    private function buildSupervisorOptionsForBusqueda(Request $request, string $primaryRole): Collection
-    {
-        $query = Supervisor::query()
-            ->select('id', 'nombre', 'apellido_p', 'apellido_m', 'ejecutivo_id')
-            ->orderBy('nombre')
-            ->orderBy('apellido_p')
-            ->orderBy('apellido_m');
-
-        if ($primaryRole === 'ejecutivo') {
-            $ejecutivo = Ejecutivo::firstWhere('user_id', $request->user()?->id);
-            abort_if(!$ejecutivo, 403, 'Perfil de ejecutivo no configurado.');
-
-            $query->where('ejecutivo_id', $ejecutivo->id);
-        }
-
-        return $query->get()->map(function (Supervisor $supervisor) {
-            return [
-                'id' => $supervisor->id,
-                'nombre' => collect([
-                    $supervisor->nombre,
-                    $supervisor->apellido_p,
-                    $supervisor->apellido_m,
-                ])->filter()->implode(' '),
-            ];
-        });
-    }
-
     /*
      * -----------------------------------------------------------------
      * Faltan metodos para Cartera Activa, Falla Actual, Cartera Vencida, Cartera Inactiva

--- a/app/Http/Controllers/SupervisorController.php
+++ b/app/Http/Controllers/SupervisorController.php
@@ -1294,11 +1294,13 @@ class SupervisorController extends Controller
         }
 
         $busqueda = $busquedaService->buscar($request, $supervisor);
+        $supervisores = $this->buildSupervisorOptionsForBusqueda($request, $primaryRole);
+        $supervisorContextQuery = $request->attributes->get('supervisor_context_query', []);
 
         return view('mobile.supervisor.busqueda.busqueda', array_merge($busqueda, [
             'role' => $primaryRole,
-            'supervisores' => collect(),
-            'supervisorContextQuery' => $request->attributes->get('supervisor_context_query', []),
+            'supervisores' => $supervisores,
+            'supervisorContextQuery' => $supervisorContextQuery,
         ]));
     }
 


### PR DESCRIPTION
## Summary
- centralize supervisor option lookup for search flows in `HandlesSupervisorContext`
- let the supervisor search view expose available supervisors to executive and admin roles
- reuse the shared helper in the ejecutivo search flow to avoid duplicated logic

## Testing
- `php artisan test tests/Feature/EjecutivoBusquedaClientesTest.php` *(fails: SQLSTATE[HY000]: General error: 1 table promotores has no column named dias_de_pago)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fda6550c8325a4f90f1e8b734478