### PR TITLE
Adjust busqueda visibility and restrict sensitive details

### DIFF
--- a/database/seeders/BusquedaClientesSeeder.php
+++ b/database/seeders/BusquedaClientesSeeder.php
@@ -11,6 +11,7 @@ use App\Models\Supervisor;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
 use Spatie\Permission\Models\Role;
 
 class BusquedaClientesSeeder extends Seeder
@@ -143,7 +144,7 @@ class BusquedaClientesSeeder extends Seeder
 
         $promotorUno = Promotor::updateOrCreate(
             ['user_id' => $promotorUnoUser->id],
-            [
+            array_merge([
                 'supervisor_id' => $supervisorUno->id,
                 'nombre' => 'Pamela',
                 'apellido_p' => 'Jimenez',
@@ -152,15 +153,14 @@ class BusquedaClientesSeeder extends Seeder
                 'colonia' => 'Centro',
                 'venta_proyectada_objetivo' => 60000,
                 'bono' => 0,
-                'dias_de_pago' => 'lunes, jueves',
                 'creado_en' => now(),
                 'actualizado_en' => now(),
-            ]
+            ], $this->promotorScheduleData('lunes, jueves'))
         );
 
         $promotorDos = Promotor::updateOrCreate(
             ['user_id' => $promotorDosUser->id],
-            [
+            array_merge([
                 'supervisor_id' => $supervisorDos->id,
                 'nombre' => 'Pablo',
                 'apellido_p' => 'Ruiz',
@@ -169,10 +169,9 @@ class BusquedaClientesSeeder extends Seeder
                 'colonia' => 'Norte',
                 'venta_proyectada_objetivo' => 50000,
                 'bono' => 0,
-                'dias_de_pago' => 'martes, viernes',
                 'creado_en' => now(),
                 'actualizado_en' => now(),
-            ]
+            ], $this->promotorScheduleData('martes, viernes'))
         );
 
         $clienteUno = Cliente::updateOrCreate(
@@ -277,5 +276,22 @@ class BusquedaClientesSeeder extends Seeder
         foreach (['ejecutivo', 'administrativo', 'supervisor', 'promotor'] as $role) {
             Role::firstOrCreate(['name' => $role, 'guard_name' => 'web']);
         }
+    }
+
+    private function promotorScheduleData(string $diasPago): array
+    {
+        if (Schema::hasColumn('promotores', 'dias_de_pago')) {
+            return ['dias_de_pago' => $diasPago];
+        }
+
+        $dia = collect(explode(',', $diasPago))
+            ->map(fn ($value) => trim((string) $value))
+            ->filter()
+            ->first();
+
+        return [
+            'dia_de_pago' => $dia ?: null,
+            'hora_de_pago' => null,
+        ];
     }
 }

--- a/resources/views/mobile/supervisor/busqueda/partials/form-results.blade.php
+++ b/resources/views/mobile/supervisor/busqueda/partials/form-results.blade.php
@@ -72,7 +72,10 @@
                 @else
                     <div class="space-y-3">
                         @foreach($resultados as $resultado)
-                            @php $detailEnabled = (bool) ($resultado['puede_detallar'] ?? false); @endphp
+                            @php
+                                $detailEnabled = (bool) ($resultado['puede_detallar'] ?? false);
+                                $detalle = $resultado['detalle'] ?? null;
+                            @endphp
                             <div x-data="{ detail: false }" class="border border-gray-200 rounded-xl shadow-sm">
                                 <div class="flex items-start justify-between gap-3 p-3">
                                     <div class="min-w-0 space-y-1">
@@ -103,106 +106,127 @@
                                     </div>
                                 </div>
 
-                                <div x-show="detail" x-cloak @click.self="detail = false" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
-                                    <div class="relative w-full max-w-md bg-white rounded-2xl shadow-xl p-5 space-y-4">
-                                        <button
-                                            class="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
-                                            @click="detail = false"
-                                            type="button"
-                                        >✕</button>
+                                @if($detailEnabled && $detalle)
+                                    <div x-show="detail" x-cloak @click.self="detail = false" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+                                        <div class="relative w-full max-w-md bg-white rounded-2xl shadow-xl p-5 space-y-4">
+                                            <button
+                                                class="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+                                                @click="detail = false"
+                                                type="button"
+                                            >✕</button>
 
-                                        <div class="space-y-1">
-                                            <h2 class="text-lg font-bold text-gray-900">{{ $resultado['nombre'] }}</h2>
-                                            <p class="text-xs text-gray-600">Supervisor: <span class="font-semibold text-gray-800">{{ $resultado['detalle']['supervisor'] }}</span></p>
-                                            <p class="text-xs text-gray-600">Estatus del crédito: <span class="font-semibold text-gray-800">{{ $resultado['detalle']['estatus_credito'] }}</span></p>
-                                        </div>
-
-                                        <div class="space-y-3">
                                             <div class="space-y-1">
-                                                <h3 class="text-sm font-semibold text-gray-900">Cliente</h3>
-                                                @php
-                                                    $telefonosCliente = collect($resultado['detalle']['cliente']['telefonos'] ?? [])->filter()->implode(', ');
-                                                @endphp
-                                                <p class="text-xs text-gray-600">Teléfono(s): <span class="font-semibold text-gray-800">{{ $telefonosCliente !== '' ? $telefonosCliente : 'Sin teléfono registrado' }}</span></p>
-                                                <p class="text-xs text-gray-600">Domicilio: <span class="font-semibold text-gray-800">{{ $resultado['detalle']['cliente']['domicilio'] ?? 'Sin domicilio registrado' }}</span></p>
-
-                                                <div class="space-y-1">
-                                                    <p class="text-xs font-semibold text-gray-700">INE</p>
-                                                    @php $docsClienteIne = collect($resultado['detalle']['cliente']['documentos']['ine'] ?? []); @endphp
-                                                    @if($docsClienteIne->isEmpty())
-                                                        <p class="text-[11px] text-gray-400">Sin fotografías de INE.</p>
-                                                    @else
-                                                        <div class="grid grid-cols-2 gap-2">
-                                                            @foreach($docsClienteIne as $doc)
-                                                                @if(!empty($doc['url']))
-                                                                    <img src="{{ $doc['url'] }}" alt="INE del cliente" class="rounded-lg object-cover" />
-                                                                @endif
-                                                            @endforeach
-                                                        </div>
-                                                    @endif
-                                                </div>
-
-                                                <div class="space-y-1">
-                                                    <p class="text-xs font-semibold text-gray-700">Comprobante de domicilio</p>
-                                                    @php $docsClienteDom = collect($resultado['detalle']['cliente']['documentos']['comprobante'] ?? []); @endphp
-                                                    @if($docsClienteDom->isEmpty())
-                                                        <p class="text-[11px] text-gray-400">Sin comprobantes de domicilio.</p>
-                                                    @else
-                                                        <div class="grid grid-cols-2 gap-2">
-                                                            @foreach($docsClienteDom as $doc)
-                                                                @if(!empty($doc['url']))
-                                                                    <img src="{{ $doc['url'] }}" alt="Comprobante del cliente" class="rounded-lg object-cover" />
-                                                                @endif
-                                                            @endforeach
-                                                        </div>
-                                                    @endif
-                                                </div>
+                                                <h2 class="text-lg font-bold text-gray-900">{{ $resultado['nombre'] }}</h2>
+                                                <p class="text-xs text-gray-600">Supervisor: <span class="font-semibold text-gray-800">{{ $detalle['supervisor'] ?? 'Sin supervisor' }}</span></p>
+                                                <p class="text-xs text-gray-600">Estatus del crédito: <span class="font-semibold text-gray-800">{{ $detalle['estatus_credito'] ?? 'Sin crédito' }}</span></p>
                                             </div>
 
+                                            <div class="space-y-3">
+                                                <div class="space-y-1">
+                                                    <h3 class="text-sm font-semibold text-gray-900">Cliente</h3>
+                                                    @php
+                                                        $telefonosCliente = collect($detalle['cliente']['telefonos'] ?? [])->filter()->implode(', ');
+                                                    @endphp
+                                                    <p class="text-xs text-gray-600">Teléfono(s): <span class="font-semibold text-gray-800">{{ $telefonosCliente !== '' ? $telefonosCliente : 'Sin teléfono registrado' }}</span></p>
+                                                    <p class="text-xs text-gray-600">Domicilio: <span class="font-semibold text-gray-800">{{ $detalle['cliente']['domicilio'] ?? 'Sin domicilio registrado' }}</span></p>
+
+                                                    <div class="space-y-1">
+                                                        <p class="text-xs font-semibold text-gray-700">INE</p>
+                                                        @php $docsClienteIne = collect($detalle['cliente']['documentos']['ine'] ?? []); @endphp
+                                                        @if($docsClienteIne->isEmpty())
+                                                            <p class="text-[11px] text-gray-400">Sin fotografías de INE.</p>
+                                                        @else
+                                                            <div class="grid grid-cols-2 gap-2">
+                                                                @foreach($docsClienteIne as $doc)
+                                                                    @if(!empty($doc['url']))
+                                                                        <img src="{{ $doc['url'] }}" alt="INE del cliente" class="rounded-lg object-cover" />
+                                                                    @endif
+                                                                @endforeach
+                                                            </div>
+                                                        @endif
+                                                    </div>
+
+                                                    <div class="space-y-1">
+                                                        <p class="text-xs font-semibold text-gray-700">Comprobante de domicilio</p>
+                                                        @php $docsClienteDom = collect($detalle['cliente']['documentos']['comprobante'] ?? []); @endphp
+                                                        @if($docsClienteDom->isEmpty())
+                                                            <p class="text-[11px] text-gray-400">Sin comprobantes de domicilio.</p>
+                                                        @else
+                                                            <div class="grid grid-cols-2 gap-2">
+                                                                @foreach($docsClienteDom as $doc)
+                                                                    @if(!empty($doc['url']))
+                                                                        <img src="{{ $doc['url'] }}" alt="Comprobante del cliente" class="rounded-lg object-cover" />
+                                                                    @endif
+                                                                @endforeach
+                                                            </div>
+                                                        @endif
+                                                    </div>
+                                                </div>
+
+                                                <div class="space-y-1">
+                                                    <h3 class="text-sm font-semibold text-gray-900">Aval</h3>
+                                                    <p class="text-xs text-gray-600">Nombre: <span class="font-semibold text-gray-800">{{ $detalle['aval']['nombre'] ?? 'Sin aval' }}</span></p>
+                                                    @php
+                                                        $telefonosAval = collect($detalle['aval']['telefonos'] ?? [])->filter()->implode(', ');
+                                                    @endphp
+                                                    <p class="text-xs text-gray-600">Teléfono(s): <span class="font-semibold text-gray-800">{{ $telefonosAval !== '' ? $telefonosAval : 'Sin teléfono registrado' }}</span></p>
+                                                    <p class="text-xs text-gray-600">Domicilio: <span class="font-semibold text-gray-800">{{ $detalle['aval']['domicilio'] ?? 'Sin domicilio registrado' }}</span></p>
+
+                                                    <div class="space-y-1">
+                                                        <p class="text-xs font-semibold text-gray-700">INE</p>
+                                                        @php $docsAvalIne = collect($detalle['aval']['documentos']['ine'] ?? []); @endphp
+                                                        @if($docsAvalIne->isEmpty())
+                                                            <p class="text-[11px] text-gray-400">Sin fotografías de INE del aval.</p>
+                                                        @else
+                                                            <div class="grid grid-cols-2 gap-2">
+                                                                @foreach($docsAvalIne as $doc)
+                                                                    @if(!empty($doc['url']))
+                                                                        <img src="{{ $doc['url'] }}" alt="INE del aval" class="rounded-lg object-cover" />
+                                                                    @endif
+                                                                @endforeach
+                                                            </div>
+                                                        @endif
+                                                    </div>
+
+                                                    <div class="space-y-1">
+                                                        <p class="text-xs font-semibold text-gray-700">Comprobante de domicilio</p>
+                                                        @php $docsAvalDom = collect($detalle['aval']['documentos']['comprobante'] ?? []); @endphp
+                                                        @if($docsAvalDom->isEmpty())
+                                                            <p class="text-[11px] text-gray-400">Sin comprobantes de domicilio del aval.</p>
+                                                        @else
+                                                            <div class="grid grid-cols-2 gap-2">
+                                                                @foreach($docsAvalDom as $doc)
+                                                                    @if(!empty($doc['url']))
+                                                                        <img src="{{ $doc['url'] }}" alt="Comprobante del aval" class="rounded-lg object-cover" />
+                                                                    @endif
+                                                                @endforeach
+                                                            </div>
+                                                        @endif
+                                                    </div>
+                                                </div>
                                             <div class="space-y-1">
-                                                <h3 class="text-sm font-semibold text-gray-900">Aval</h3>
-                                                <p class="text-xs text-gray-600">Nombre: <span class="font-semibold text-gray-800">{{ $resultado['detalle']['aval']['nombre'] }}</span></p>
-                                                @php
-                                                    $telefonosAval = collect($resultado['detalle']['aval']['telefonos'] ?? [])->filter()->implode(', ');
-                                                @endphp
-                                                <p class="text-xs text-gray-600">Teléfono(s): <span class="font-semibold text-gray-800">{{ $telefonosAval !== '' ? $telefonosAval : 'Sin teléfono registrado' }}</span></p>
-                                                <p class="text-xs text-gray-600">Domicilio: <span class="font-semibold text-gray-800">{{ $resultado['detalle']['aval']['domicilio'] ?? 'Sin domicilio registrado' }}</span></p>
-
-                                                <div class="space-y-1">
-                                                    <p class="text-xs font-semibold text-gray-700">INE</p>
-                                                    @php $docsAvalIne = collect($resultado['detalle']['aval']['documentos']['ine'] ?? []); @endphp
-                                                    @if($docsAvalIne->isEmpty())
-                                                        <p class="text-[11px] text-gray-400">Sin fotografías de INE del aval.</p>
-                                                    @else
-                                                        <div class="grid grid-cols-2 gap-2">
-                                                            @foreach($docsAvalIne as $doc)
-                                                                @if(!empty($doc['url']))
-                                                                    <img src="{{ $doc['url'] }}" alt="INE del aval" class="rounded-lg object-cover" />
-                                                                @endif
-                                                            @endforeach
-                                                        </div>
-                                                    @endif
-                                                </div>
-
-                                                <div class="space-y-1">
-                                                    <p class="text-xs font-semibold text-gray-700">Comprobante de domicilio</p>
-                                                    @php $docsAvalDom = collect($resultado['detalle']['aval']['documentos']['comprobante'] ?? []); @endphp
-                                                    @if($docsAvalDom->isEmpty())
-                                                        <p class="text-[11px] text-gray-400">Sin comprobantes de domicilio del aval.</p>
-                                                    @else
-                                                        <div class="grid grid-cols-2 gap-2">
-                                                            @foreach($docsAvalDom as $doc)
-                                                                @if(!empty($doc['url']))
-                                                                    <img src="{{ $doc['url'] }}" alt="Comprobante del aval" class="rounded-lg object-cover" />
-                                                                @endif
-                                                            @endforeach
-                                                        </div>
-                                                    @endif
-                                                </div>
+                                                <h3 class="text-sm font-semibold text-gray-900">Garantías</h3>
+                                                @php $garantias = collect($detalle['garantias'] ?? []); @endphp
+                                                @if($garantias->isEmpty())
+                                                    <p class="text-[11px] text-gray-400">Sin garantías registradas.</p>
+                                                @else
+                                                    <ul class="space-y-1 text-xs text-gray-600">
+                                                        @foreach($garantias as $garantia)
+                                                            <li class="flex items-start gap-2">
+                                                                <span class="text-gray-400">•</span>
+                                                                <span>
+                                                                    <span class="font-semibold text-gray-800">{{ data_get($garantia, 'tipo', 'Garantía') }}:</span>
+                                                                    {{ data_get($garantia, 'descripcion', data_get($garantia, 'marca')) }}
+                                                                </span>
+                                                            </li>
+                                                        @endforeach
+                                                    </ul>
+                                                @endif
+                                            </div>
                                             </div>
                                         </div>
                                     </div>
-                                </div>
+                                @endif
                             </div>
                         @endforeach
                     </div>

--- a/tests/Feature/EjecutivoBusquedaClientesTest.php
+++ b/tests/Feature/EjecutivoBusquedaClientesTest.php
@@ -39,7 +39,7 @@ beforeEach(function () {
     }
 });
 
-it('permite que un ejecutivo solo vea clientes de sus supervisores asignados', function () {
+it('permite que un ejecutivo identifique clientes ajenos en los resultados', function () {
     $this->seed(BusquedaClientesSeeder::class);
 
     $ejecutivoUser = User::firstWhere('email', 'ejecutivo.busqueda@example.com');
@@ -52,7 +52,9 @@ it('permite que un ejecutivo solo vea clientes de sus supervisores asignados', f
     $response
         ->assertOk()
         ->assertSee('Carolina Miranda', escape: false)
-        ->assertDontSee('Carlos Nava');
+        ->assertSee('Carlos Nava', escape: false)
+        ->assertSee('Asignado a otro supervisor', escape: false)
+        ->assertSee('cursor-not-allowed', escape: false);
 });
 
 it('permite que un administrativo consulte clientes de cualquier supervisor', function () {

--- a/tests/Feature/SupervisorBusquedaClientesTest.php
+++ b/tests/Feature/SupervisorBusquedaClientesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Models\User;
+use Database\Seeders\BusquedaClientesSeeder;
+use Spatie\Permission\PermissionRegistrar;
+
+$kanbanTestPath = dirname(__DIR__, 2) . '/database/kanban_test.sqlite';
+putenv('KANBAN_DB_DATABASE=' . $kanbanTestPath);
+$_ENV['KANBAN_DB_DATABASE'] = $kanbanTestPath;
+$_SERVER['KANBAN_DB_DATABASE'] = $kanbanTestPath;
+
+if (file_exists($kanbanTestPath)) {
+    unlink($kanbanTestPath);
+}
+
+if (!file_exists($kanbanTestPath)) {
+    touch($kanbanTestPath);
+}
+
+$envPath = dirname(__DIR__, 2) . '/.env';
+if (!file_exists($envPath)) {
+    file_put_contents($envPath, "");
+}
+
+beforeEach(function () {
+    global $kanbanTestPath;
+
+    config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+    $this->withoutVite();
+
+    if (file_exists($kanbanTestPath)) {
+        unlink($kanbanTestPath);
+    }
+
+    if (!file_exists($kanbanTestPath)) {
+        touch($kanbanTestPath);
+    }
+});
+
+it('muestra un cliente de otro supervisor con detalle restringido', function () {
+    $this->seed(BusquedaClientesSeeder::class);
+
+    $supervisorUser = User::firstWhere('email', 'supervisor.busqueda@example.com');
+    expect($supervisorUser)->not()->toBeNull();
+
+    $response = $this->actingAs($supervisorUser)
+        ->withSession([])
+        ->get(route('mobile.supervisor.busqueda', ['q' => 'Carlos']));
+
+    $response
+        ->assertOk()
+        ->assertSee('Carlos Nava', escape: false)
+        ->assertSee('Detalles</button>', escape: false)
+        ->assertSee('cursor-not-allowed', escape: false)
+        ->assertSee('Asignado a otro supervisor', escape: false)
+        ->assertDontSee('5598765432')
+        ->assertDontSee('Industrial')
+        ->assertDontSee('INE del cliente');
+});


### PR DESCRIPTION
## Summary
- allow the mobile client search service to return non-context clients while suppressing sensitive payloads for those outside the supervisor’s remit
- guard the mobile search modal so the detail dialog only renders when details are available, keeping guarantees output intact
- make the BusquedaClientes seeder compatible with both schedule column variants and expand feature coverage for executives and supervisors

## Testing
- php artisan test --filter=BusquedaClientes

------
https://chatgpt.com/codex/tasks/task_e_68d502d366f483259956a69ede4dd4f1