### PR TITLE
Allow executives to view client details without selecting supervisors

### DIFF
--- a/resources/views/mobile/supervisor/busqueda/partials/form-results.blade.php
+++ b/resources/views/mobile/supervisor/busqueda/partials/form-results.blade.php
@@ -10,13 +10,14 @@
     $isExecutiveContext = in_array($role, ['ejecutivo', 'administrativo', 'superadmin'], true);
     $searchRoute = $isExecutiveContext ? 'mobile.ejecutivo.busqueda' : 'mobile.supervisor.busqueda';
     $backRoute = $isExecutiveContext ? 'mobile.ejecutivo.index' : 'mobile.supervisor.index';
-    $showSupervisorSelector = $isExecutiveContext && $supervisores->isNotEmpty();
+    $showSupervisorSelector = in_array($role, ['administrativo', 'superadmin'], true) && $supervisores->isNotEmpty();
+    $preservedQueryParams = collect($supervisorContextQuery)->when(!$showSupervisorSelector, fn ($params) => $params->except('supervisor'))->all();
 @endphp
 
 <div class="bg-white rounded-2xl shadow-md p-6 w-full max-w-md space-y-6">
     <h1 class="text-xl font-bold text-gray-900 text-center">Ingresa tu búsqueda</h1>
 
-    <form method="GET" action="{{ route($searchRoute, array_merge($supervisorContextQuery, [])) }}" class="space-y-4">
+    <form method="GET" action="{{ route($searchRoute, $preservedQueryParams) }}" class="space-y-4">
         @if($showSupervisorSelector)
             <div class="space-y-1">
                 <label for="supervisor" class="block text-sm font-semibold text-gray-700">Supervisor</label>
@@ -52,7 +53,7 @@
                 class="flex-1 py-2 bg-blue-800 text-white font-semibold rounded-lg hover:bg-blue-900 shadow-sm"
             >Buscar</button>
             <a
-                href="{{ route($backRoute, array_merge($supervisorContextQuery, [])) }}"
+                href="{{ route($backRoute, $preservedQueryParams) }}"
                 class="flex-1 py-2 text-center bg-gray-300 text-gray-700 font-semibold rounded-lg hover:bg-gray-400"
             >Regresar</a>
         </div>

--- a/tests/Feature/EjecutivoBusquedaClientesTest.php
+++ b/tests/Feature/EjecutivoBusquedaClientesTest.php
@@ -1,9 +1,15 @@
 <?php
 
+use App\Models\Cliente;
+use App\Models\Credito;
+use App\Models\DatoContacto;
+use App\Models\Ejecutivo;
+use App\Models\Promotor;
 use App\Models\Supervisor;
 use App\Models\User;
 use Database\Seeders\BusquedaClientesSeeder;
 use Spatie\Permission\PermissionRegistrar;
+use Illuminate\Support\Facades\Schema;
 
 $kanbanTestPath = dirname(__DIR__, 2) . '/database/kanban_test.sqlite';
 putenv('KANBAN_DB_DATABASE=' . $kanbanTestPath);
@@ -55,6 +61,116 @@ it('permite que un ejecutivo identifique clientes ajenos en los resultados', fun
         ->assertSee('Carlos Nava', escape: false)
         ->assertSee('Asignado a otro supervisor', escape: false)
         ->assertSee('cursor-not-allowed', escape: false);
+});
+
+it('habilita detalles sin seleccionar supervisor para todos los clientes de sus supervisores', function () {
+    $this->seed(BusquedaClientesSeeder::class);
+
+    $ejecutivoUser = User::firstWhere('email', 'ejecutivo.busqueda@example.com');
+    expect($ejecutivoUser)->not()->toBeNull();
+
+    $ejecutivo = Ejecutivo::firstWhere('user_id', $ejecutivoUser->id);
+    expect($ejecutivo)->not()->toBeNull();
+
+    $nuevoSupervisorUser = User::factory()->create([
+        'rol' => 'supervisor',
+        'remember_token' => false,
+    ]);
+    $nuevoSupervisorUser->assignRole('supervisor');
+
+    $nuevoSupervisor = Supervisor::create([
+        'user_id' => $nuevoSupervisorUser->id,
+        'ejecutivo_id' => $ejecutivo->id,
+        'nombre' => 'Silvia',
+        'apellido_p' => 'Campos',
+        'apellido_m' => 'Luna',
+    ]);
+
+    $nuevoPromotorUser = User::factory()->create([
+        'rol' => 'promotor',
+        'remember_token' => false,
+    ]);
+    $nuevoPromotorUser->assignRole('promotor');
+
+    $nuevoPromotorData = [
+        'user_id' => $nuevoPromotorUser->id,
+        'supervisor_id' => $nuevoSupervisor->id,
+        'nombre' => 'Paula',
+        'apellido_p' => 'Jimenez',
+        'apellido_m' => 'Cruz',
+        'venta_maxima' => 11000,
+        'colonia' => 'Centro',
+        'venta_proyectada_objetivo' => 40000,
+        'bono' => 0,
+        'creado_en' => now(),
+        'actualizado_en' => now(),
+    ];
+
+    if (Schema::hasColumn('promotores', 'dias_de_pago')) {
+        $nuevoPromotorData['dias_de_pago'] = 'miercoles';
+    } else {
+        $nuevoPromotorData['dia_de_pago'] = 'miercoles';
+        $nuevoPromotorData['hora_de_pago'] = '11:30';
+    }
+
+    $nuevoPromotor = Promotor::create($nuevoPromotorData);
+
+    $nuevoCliente = Cliente::create([
+        'promotor_id' => $nuevoPromotor->id,
+        'CURP' => 'BUSQCLIENTE003',
+        'nombre' => 'Carla',
+        'apellido_p' => 'Jimenez',
+        'apellido_m' => 'Lopez',
+        'fecha_nacimiento' => '1992-03-10',
+        'tiene_credito_activo' => true,
+        'cartera_estado' => 'activo',
+        'monto_maximo' => 18000,
+        'horario_de_pago' => '11:00',
+        'creado_en' => now(),
+        'actualizado_en' => now(),
+        'activo' => true,
+    ]);
+
+    $nuevoCredito = Credito::create([
+        'cliente_id' => $nuevoCliente->id,
+        'monto_total' => 18000,
+        'estado' => 'activo',
+        'interes' => 1.5,
+        'periodicidad' => 'Semanal',
+        'fecha_inicio' => now()->subWeeks(1),
+        'fecha_final' => now()->addMonths(6),
+    ]);
+
+    DatoContacto::create([
+        'credito_id' => $nuevoCredito->id,
+        'calle' => 'Calle Tercera',
+        'numero_ext' => '10',
+        'numero_int' => '1',
+        'monto_mensual' => 3800,
+        'colonia' => 'Centro',
+        'municipio' => 'Ciudad Busqueda',
+        'estado' => 'CDMX',
+        'cp' => '03000',
+        'tiempo_en_residencia' => '2 años',
+        'tel_fijo' => null,
+        'tel_cel' => '5511122233',
+        'tipo_de_vivienda' => 'Rentada',
+        'creado_en' => now(),
+    ]);
+
+    $response = $this->actingAs($ejecutivoUser)
+        ->withSession([])
+        ->get(route('mobile.ejecutivo.busqueda', ['q' => 'Car']));
+
+    $response
+        ->assertOk()
+        ->assertSee('Carolina Miranda', escape: false)
+        ->assertSee('Carla Jimenez', escape: false);
+
+    $content = $response->getContent();
+
+    expect(substr_count($content, 'bg-blue-600 text-white hover:bg-blue-700'))->toBe(2);
+    expect(substr_count($content, 'cursor-not-allowed'))->toBe(1);
 });
 
 it('permite que un administrativo consulte clientes de cualquier supervisor', function () {


### PR DESCRIPTION
## Summary
- hide the supervisor selector for executive searches and strip the query parameter when it is not shown
- gather all accessible promotores for the authenticated executive and pass them to the client search service
- extend the search service to accept custom promotor contexts and cover the new behaviour with an additional feature test

## Testing
- php artisan test --filter=EjecutivoBusquedaClientesTest
- php artisan test --filter=SupervisorBusquedaClientesTest


------
https://chatgpt.com/codex/tasks/task_e_68d5081c8bf4832583769a14ae8cd540