### PR TITLE
Reuse existing promotor hierarchy for filter demos

### DIFF
--- a/app/Http/Controllers/FiltrosController.php
+++ b/app/Http/Controllers/FiltrosController.php
@@ -12,8 +12,8 @@ use Illuminate\Support\Str;
 /*
  * Demo filters data (RealisticFilterCasesSeeder):
  * - Run seeder: php artisan db:seed --class=RealisticFilterCasesSeeder
- * - Promotor principal: filtros.promotor@example.com (password: Filtros2024!)
- * - Promotor alterno: filtros.promotor.alt@example.com (password: Filtros2024!)
+ * - Promotor principal: promotor@example.com (password: Filtros2024!)
+ * - Promotor alterno: promotor2@example.com (password: Filtros2024!)
  * - Obten clientes con Cliente::where('CURP', '...')->firstOrFail()
  * - Escenarios con app(self::class)->evaluar($cliente, $form, $contexto):
  *   curp_unica => cliente Laura Cardenas Lopez (CURP RFCD900101HDFLLA01)
@@ -27,7 +27,7 @@ use Illuminate\Support\Str;
  *                      Contexto: ['tipo_solicitud' => 'nuevo']
  *   otra_plaza => cliente Hector Estrada Nolasco (CURP RFOP900909HDFLHE07)
  *                 Contexto: ['promotor_id' => $promotorAlterno->id, 'supervisor_id' => $promotorAlterno->supervisor_id]
- *                 Nota: $promotorAlterno es el promotor del correo filtros.promotor.alt@example.com
+ *                 Nota: $promotorAlterno es el promotor del correo promotor2@example.com
  *   bloqueo_falla_promotora_5 => cliente Isabel Quintero (CURP RFPF911111HDFLKK18)
  *                                 Contexto: ['tipo_solicitud' => 'nuevo']
  *   doble_domicilio => cliente Laura Alvarado Campos (CURP RFDD930303HDFLLA20)

--- a/database/seeders/RealisticFilterCasesSeeder.php
+++ b/database/seeders/RealisticFilterCasesSeeder.php
@@ -100,7 +100,7 @@ class RealisticFilterCasesSeeder extends Seeder
     private function ensureHierarchy(): array
     {
         $ejecutivoUser = $this->ensureUser(
-            'filtros.ejecutivo@example.com',
+            'ejecutivo@example.com',
             'Ernesto Campos Delgado',
             'ejecutivo',
             '5552000001'
@@ -116,7 +116,7 @@ class RealisticFilterCasesSeeder extends Seeder
         );
 
         $supervisorUser = $this->ensureUser(
-            'filtros.supervisor@example.com',
+            'supervisor@example.com',
             'Beatriz Mendoza Rios',
             'supervisor',
             '5552000002'
@@ -133,7 +133,7 @@ class RealisticFilterCasesSeeder extends Seeder
         );
 
         $promotorPrincipalUser = $this->ensureUser(
-            'filtros.promotor@example.com',
+            'promotor@example.com',
             'Claudia Vazquez Romero',
             'promotor',
             '5552000003'
@@ -156,7 +156,7 @@ class RealisticFilterCasesSeeder extends Seeder
         );
 
         $promotorSecundarioUser = $this->ensureUser(
-            'filtros.promotor.alt@example.com',
+            'promotor2@example.com',
             'Luis Serrano Cano',
             'promotor',
             '5552000004'


### PR DESCRIPTION
## Summary
- update the realistic filter seeder to reuse the existing ejecutivo, supervisor, and promotor accounts (promotor@example.com / promotor2@example.com)
- keep all seeded clients linked to the shared promotor hierarchy so demo filters run against the canonical login
- refresh the filtros controller guidance comment so it points at the corrected demo credentials

## Testing
- php artisan migrate --force
- php artisan db:seed --class=RealisticFilterCasesSeeder --force

------
https://chatgpt.com/codex/tasks/task_e_68d64996b58c8325be850860dc3ca347