### PR TITLE
Fix executive cartera metrics for active credit statuses

### DIFF
--- a/app/Http/Controllers/FiltrosController.php
+++ b/app/Http/Controllers/FiltrosController.php
@@ -52,7 +52,7 @@ class FiltrosController extends Controller
     public const FILTER_DOBLE_DOMICILIO = 'doble_domicilio';
     public const FILTER_BLOQUEO_TIEMPO_REACREDITOS = 'bloqueo_tiempo_recreditos';
 
-    private const CREDIT_ACTIVE_STATES = [
+    public const CREDIT_ACTIVE_STATES = [
         'prospectado',
         'prospectado_recredito',
         'solicitado',
@@ -61,7 +61,7 @@ class FiltrosController extends Controller
         'desembolsado',
     ];
 
-    private const CREDIT_FAILURE_STATES = [
+    public const CREDIT_FAILURE_STATES = [
         'vencido',
     ];
 

--- a/resources/views/mobile/ejecutivo/cartera/cartera.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera.blade.php
@@ -15,6 +15,8 @@
   $cartera_inactivaP = $cartera_inactivaP ?? 0;
 
   /** ================= Helpers inline (sustitutos simples de X-Components) ================= */
+  $formatMoney = fn($value) => '$' . number_format((float) $value, 2, '.', ',');
+  $formatPercentage = fn($value) => number_format((float) $value, 2, '.', ',') . '%';
   $statRow = function(string $label, $value = null, $slotHtml = null) {
       $left  = '<span class="text-sm text-gray-600">'.e($label).'</span>';
       $right = !is_null($value)
@@ -63,7 +65,7 @@
             <div class="flex items-center justify-between">
               <span class="text-sm text-gray-700">Cartera Activa</span>
               <div class="flex items-center gap-3">
-                <span class="text-sm font-semibold text-gray-900">{{ $cartera_activa }}</span>
+                <span class="text-sm font-semibold text-gray-900">{{ $formatMoney($cartera_activa) }}</span>
                 {!! $pillLink(route('mobile.'.$role.'.cartera_activa'), 'D') !!}
               </div>
             </div>
@@ -73,7 +75,7 @@
             <div class="flex items-center justify-between">
               <span class="text-sm text-gray-700">Falla Actual</span>
               <div class="flex items-center gap-3">
-                <span class="text-sm font-semibold text-gray-900">{{ $cartera_falla }}</span>
+                <span class="text-sm font-semibold text-gray-900">{{ $formatMoney($cartera_falla) }}</span>
                 {!! $pillLink(route('mobile.'.$role.'.cartera_falla'), 'D') !!}
               </div>
             </div>
@@ -83,7 +85,7 @@
             <div class="flex items-center justify-between">
               <span class="text-sm text-gray-700">Cartera Vencida</span>
               <div class="flex items-center gap-3">
-                <span class="text-sm font-semibold text-gray-900">{{ $cartera_vencida }}</span>
+                <span class="text-sm font-semibold text-gray-900">{{ $formatMoney($cartera_vencida) }}</span>
                 {!! $pillLink(route('mobile.'.$role.'.cartera_vencida'), 'D') !!}
               </div>
             </div>
@@ -93,7 +95,7 @@
             <div class="flex items-center justify-between">
               <span class="text-sm text-gray-700">Cartera Inactiva</span>
               <div class="flex items-center gap-3">
-                <span class="text-sm font-semibold text-gray-900">{{ $cartera_inactivaP }}</span>
+                <span class="text-sm font-semibold text-gray-900">{{ $formatPercentage($cartera_inactivaP) }}</span>
                 {!! $pillLink(route('mobile.'.$role.'.cartera_inactiva'), 'D') !!}
               </div>
             </div>

--- a/tests/Feature/EjecutivoCarteraMetricsTest.php
+++ b/tests/Feature/EjecutivoCarteraMetricsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Models\Cliente;
+use App\Models\Credito;
+use App\Models\Ejecutivo;
+use App\Models\Promotor;
+use App\Models\Supervisor;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function () {
+    config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
+    $this->withoutVite();
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    Role::firstOrCreate(['name' => 'ejecutivo', 'guard_name' => 'web']);
+    Role::firstOrCreate(['name' => 'supervisor', 'guard_name' => 'web']);
+    Role::firstOrCreate(['name' => 'promotor', 'guard_name' => 'web']);
+});
+
+it('incluye créditos desembolsados dentro de la cartera activa del ejecutivo', function () {
+    $user = User::factory()->create(['rol' => 'ejecutivo']);
+    $user->assignRole('ejecutivo');
+
+    $ejecutivo = Ejecutivo::create([
+        'user_id' => $user->id,
+        'nombre' => 'Daniela',
+        'apellido_p' => 'Soto',
+        'apellido_m' => 'Reyes',
+    ]);
+
+    $supervisorUser = User::factory()->create(['rol' => 'supervisor']);
+    $supervisorUser->assignRole('supervisor');
+
+    $supervisor = Supervisor::create([
+        'user_id' => $supervisorUser->id,
+        'ejecutivo_id' => $ejecutivo->id,
+        'nombre' => 'Marcos',
+        'apellido_p' => 'Pineda',
+        'apellido_m' => 'Lara',
+    ]);
+
+    $promotorUser = User::factory()->create(['rol' => 'promotor']);
+    $promotorUser->assignRole('promotor');
+
+    $promotor = Promotor::create([
+        'user_id' => $promotorUser->id,
+        'supervisor_id' => $supervisor->id,
+        'nombre' => 'Patricia',
+        'apellido_p' => 'Nava',
+        'apellido_m' => 'Campos',
+        'venta_maxima' => 5000,
+        'colonia' => 'Centro',
+        'venta_proyectada_objetivo' => 3000,
+        'bono' => 0,
+        'dia_de_pago' => 'Lunes',
+    ]);
+
+    $cliente = Cliente::create([
+        'promotor_id' => $promotor->id,
+        'CURP' => Str::upper(Str::random(18)),
+        'nombre' => 'Cliente Demo',
+        'apellido_p' => 'Prueba',
+        'apellido_m' => 'Activa',
+        'fecha_nacimiento' => now()->subYears(30)->toDateString(),
+        'tiene_credito_activo' => true,
+        'cartera_estado' => 'activo',
+        'monto_maximo' => 5000,
+        'creado_en' => now(),
+        'actualizado_en' => now(),
+        'activo' => true,
+    ]);
+
+    $monto = 1500.00;
+
+    Credito::create([
+        'cliente_id' => $cliente->id,
+        'monto_total' => $monto,
+        'estado' => 'desembolsado',
+        'interes' => 10,
+        'periodicidad' => 'semanal',
+        'fecha_inicio' => now()->subMonth()->toDateString(),
+        'fecha_final' => now()->addMonths(5)->toDateString(),
+    ]);
+
+    $response = $this->actingAs($user)->get(route('mobile.ejecutivo.cartera'));
+
+    $response->assertOk();
+    $response->assertViewHas('cartera_activa', round($monto, 2));
+    $response->assertSee('$1,500.00');
+});


### PR DESCRIPTION
## Summary
- reuse the shared credit status constants so executive cartera metrics count active and failure loans consistently
- update the mobile cartera view to format monetary totals and display the inactive percentage cleanly
- cover desembolsado credits in the executive cartera totals with a new feature test

## Testing
- php artisan test --filter EjecutivoCarteraMetricsTest

------
https://chatgpt.com/codex/tasks/task_e_68d70525d92c832598c2d3e7550462e5