### PR TITLE
Remove domicilio comprobante handling from mobile promotor views

### DIFF
--- a/resources/views/mobile/promotor/venta/ingresar_cliente.blade.php
+++ b/resources/views/mobile/promotor/venta/ingresar_cliente.blade.php
@@ -8,24 +8,16 @@
         errores: [],
         showError: false,
         clientCurpUploaded: false,
-        clientDomUploaded: false,
         clientIneUploaded: false,
-        clientCompUploaded: false,
         avalCurpUploaded: false,
-        avalDomUploaded: false,
         avalIneUploaded: false,
-        avalCompUploaded: false,
         r_newAval: false,
 
         // Recrédito (usar flags separados si quieres aislarlos del modal cliente)
         r_clientCurpUploaded: false,
-        r_clientDomUploaded: false,
         r_clientIneUploaded: false,
-        r_clientCompUploaded: false,
         r_avalCurpUploaded: false,
-        r_avalDomUploaded: false,
         r_avalIneUploaded: false,
-        r_avalCompUploaded: false,
 
         // Estado de inserción
         showResultado: false,
@@ -35,24 +27,16 @@
         resetClienteForm() {
           this.showCliente = false;
           this.clientCurpUploaded = false;
-          this.clientDomUploaded = false;
           this.clientIneUploaded = false;
-          this.clientCompUploaded = false;
           this.avalCurpUploaded = false;
-          this.avalDomUploaded = false;
           this.avalIneUploaded = false;
-          this.avalCompUploaded = false;
         },
         resetRecreditoForm() {
           this.showRecredito = false;
           this.r_clientCurpUploaded = false;
-          this.r_clientDomUploaded = false;
           this.r_clientIneUploaded = false;
-          this.r_clientCompUploaded = false;
           this.r_avalCurpUploaded = false;
-          this.r_avalDomUploaded = false;
           this.r_avalIneUploaded = false;
-          this.r_avalCompUploaded = false;
         },
         validateMonto(valor, max = 3000) {
           const monto = parseFloat(valor);

--- a/resources/views/mobile/promotor/venta/modal_nuevo_cliente.blade.php
+++ b/resources/views/mobile/promotor/venta/modal_nuevo_cliente.blade.php
@@ -24,23 +24,14 @@
 
         <p class="font-semibold mt-2">Monto del crédito:</p>
         <input name="monto" type="number" step="100.00" min="0" max="3000" placeholder="Monto" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-400">
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
-          
+        <div class="grid grid-cols-1 gap-3 pt-2">
+
           {{-- INE Cliente --}}
           <div>
             <label class="text-sm font-medium block mb-1">INE</label>
             <input type="file" accept="image/*,application/pdf" class="hidden" x-ref="cliIne" @change="clientIneUploaded = true">
             <button type="button" @click="$refs.cliIne.click()" :class="clientIneUploaded ? 'bg-green-600 text-white' : 'bg-yellow-400 text-black hover:bg-yellow-500'" class="w-full rounded-lg px-3 py-2 font-medium transition">
               <span x-text="clientIneUploaded ? '✔ INE cargado' : 'Subir INE'"></span>
-            </button>
-          </div>
-
-          {{-- Comprobante Domicilio Cliente --}}
-          <div>
-            <label class="text-sm font-medium block mb-1">Comprobante Domicilio</label>
-            <input type="file" accept="image/*,application/pdf" class="hidden" x-ref="cliComp" @change="clientCompUploaded = true">
-            <button type="button" @click="$refs.cliComp.click()" :class="clientCompUploaded ? 'bg-green-600 text-white' : 'bg-yellow-400 text-black hover:bg-yellow-500'" class="w-full rounded-lg px-3 py-2 font-medium transition">
-              <span x-text="clientCompUploaded ? '✔ Comprobante cargado' : 'Subir Comprobante'"></span>
             </button>
           </div>
 
@@ -59,22 +50,13 @@
         <p class="font-semibold mt-2">CURP:</p>
         <input name="aval_CURP" type="text" placeholder="CURP" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-400">
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
+        <div class="grid grid-cols-1 gap-3 pt-2">
           {{-- INE Aval --}}
           <div>
             <label class="text-sm font-medium block mb-1">INE</label>
             <input type="file" accept="image/*,application/pdf" class="hidden" x-ref="avalIne" @change="avalIneUploaded = true">
             <button type="button" @click="$refs.avalIne.click()" :class="avalIneUploaded ? 'bg-green-600 text-white' : 'bg-yellow-400 text-black hover:bg-yellow-500'" class="w-full rounded-lg px-3 py-2 font-medium transition">
               <span x-text="avalIneUploaded ? '✔ INE cargado' : 'Subir INE'"></span>
-            </button>
-          </div>
-
-          {{-- Comprobante Domicilio Aval --}}
-          <div>
-            <label class="text-sm font-medium block mb-1">Comprobante Domicilio</label>
-            <input type="file" accept="image/*,application/pdf" class="hidden" x-ref="avalComp" @change="avalCompUploaded = true">
-            <button type="button" @click="$refs.avalComp.click()" :class="avalCompUploaded ? 'bg-green-600 text-white' : 'bg-yellow-400 text-black hover:bg-yellow-500'" class="w-full rounded-lg px-3 py-2 font-medium transition">
-              <span x-text="avalCompUploaded ? '✔ Comprobante cargado' : 'Subir Comprobante'"></span>
             </button>
           </div>
         </div>

--- a/resources/views/mobile/promotor/venta/modal_recredito.blade.php
+++ b/resources/views/mobile/promotor/venta/modal_recredito.blade.php
@@ -12,9 +12,7 @@
         isLoading: false,
         r_newAval: false,
         r_clientIneUploaded: false,
-        r_clientCompUploaded: false,
         r_avalIneUploaded: false,
-        r_avalCompUploaded: false,
         result: {
             show: false,
             success: false,
@@ -47,9 +45,7 @@
                 if (response.ok) {
                     form.reset();
                     this.r_clientIneUploaded = false;
-                    this.r_clientCompUploaded = false;
                     this.r_avalIneUploaded = false;
-                    this.r_avalCompUploaded = false;
                 }
 
             } catch (error) {
@@ -65,9 +61,7 @@
             this.$refs.formRecredito.reset();
             this.r_newAval = false;
             this.r_clientIneUploaded = false;
-            this.r_clientCompUploaded = false;
             this.r_avalIneUploaded = false;
-            this.r_avalCompUploaded = false;
             this.result.show = false;
         }
     }">
@@ -117,22 +111,13 @@
                     <span class="border rounded-lg px-3 py-5 bg-gray-100"></span>
                 </div>
 
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
+                <div class="grid grid-cols-1 gap-3 pt-2">
                     {{-- INE Cliente --}}
                     <div>
                         <label class="text-sm font-medium block mb-1">INE (Opcional)</label>
                         <input type="file" name="cliente_ine" accept="image/*,application/pdf" class="hidden" x-ref="r_cliIne" @change="r_clientIneUploaded = true">
                         <button type="button" @click="$refs.r_cliIne.click()" :class="r_clientIneUploaded ? 'bg-green-600 text-white' : 'bg-yellow-400 text-black hover:bg-yellow-500'" class="w-full rounded-lg px-3 py-2 font-medium transition">
                             <span x-text="r_clientIneUploaded ? '✔ INE cargado' : 'Subir INE'"></span>
-                        </button>
-                    </div>
-
-                    {{-- Comprobante Domicilio Cliente --}}
-                    <div>
-                        <label class="text-sm font-medium block mb-1">Comprobante (Opcional)</label>
-                        <input type="file" name="cliente_comprobante" accept="image/*,application/pdf" class="hidden" x-ref="r_cliComp" @change="r_clientCompUploaded = true">
-                        <button type="button" @click="$refs.r_cliComp.click()" :class="r_clientCompUploaded ? 'bg-green-600 text-white' : 'bg-yellow-400 text-black hover:bg-yellow-500'" class="w-full rounded-lg px-3 py-2 font-medium transition">
-                            <span x-text="r_clientCompUploaded ? '✔ Comprobante cargado' : 'Subir Comprobante'"></span>
                         </button>
                     </div>
                 </div>
@@ -168,22 +153,13 @@
                        title="El CURP debe contener 18 caracteres alfanuméricos en mayúsculas."
                        @input="event.target.value = event.target.value.toUpperCase()">
 
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
+                <div class="grid grid-cols-1 gap-3 pt-2">
                     {{-- INE Aval --}}
                     <div>
                         <label class="text-sm font-medium block mb-1">INE (Opcional)</label>
                         <input name="aval_ine" type="file" accept="image/*,application/pdf" class="hidden" x-ref="r_avalIne" @change="r_avalIneUploaded = true">
                         <button type="button" @click="$refs.r_avalIne.click()" :class="r_avalIneUploaded ? 'bg-green-600 text-white' : 'bg-yellow-400 text-black hover:bg-yellow-500'" class="w-full rounded-lg px-3 py-2 font-medium transition">
                             <span x-text="r_avalIneUploaded ? '✔ INE cargado' : 'Subir INE'"></span>
-                        </button>
-                    </div>
-
-                    {{-- Comprobante Domicilio Aval --}}
-                    <div>
-                        <label class="text-sm font-medium block mb-1">Comprobante (Opcional)</label>
-                        <input name="aval_comprobante" type="file" accept="image/*,application/pdf" class="hidden" x-ref="r_avalComp" @change="r_avalCompUploaded = true">
-                        <button type="button" @click="$refs.r_avalComp.click()" :class="r_avalCompUploaded ? 'bg-green-600 text-white' : 'bg-yellow-400 text-black hover:bg-yellow-500'" class="w-full rounded-lg px-3 py-2 font-medium transition">
-                            <span x-text="r_avalCompUploaded ? '✔ Comprobante cargado' : 'Subir Comprobante'"></span>
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- remove domicilio comprobante tracking flags from the Alpine state used in the ingresar cliente view
- drop domicilio comprobante upload buttons from the nuevo cliente modal
- simplify the recrédito modal state and layout by removing optional domicilio comprobante uploads

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d709676c3c832595f103d9da4e660e