### PR TITLE
Add compliance metrics to ejecutivo cartera supervisors

### DIFF
--- a/resources/views/mobile/ejecutivo/cartera/cartera.blade.php
+++ b/resources/views/mobile/ejecutivo/cartera/cartera.blade.php
@@ -131,13 +131,13 @@
                 <div class="pt-2 border-t border-gray-100">
                   <div class="flex items-center justify-between">
                     <span class="text-xs text-gray-600">Progreso de supervisor</span>
-                    <span class="text-xs font-semibold text-gray-900">{{ $s->promotores_cumplidos ?? 0 }} / {{ $s->total_promotores ?? 0 }}</span>
+                    <span class="text-xs font-semibold text-gray-900">{{ data_get($s, 'promotores_cumplidos') }} / {{ data_get($s, 'total_promotores') }}</span>
                   </div>
                   <div class="mt-1 h-2 w-full rounded-full bg-gray-200 overflow-hidden">
-                    <div class="h-2 bg-emerald-500" style="width: {{ $s->porcentaje_cumplimiento ?? 0 }}%;"></div>
+                    <div class="h-2 bg-emerald-500" style="width: {{ (float) data_get($s, 'porcentaje_cumplimiento') }}%;"></div>
                   </div>
                   <p class="mt-1 text-xs text-gray-500">
-                    {{ number_format($s->porcentaje_cumplimiento ?? 0, 0) }}% de meta completada.
+                    {{ number_format((float) data_get($s, 'porcentaje_cumplimiento'), 0) }}% de meta completada.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- eager load promoters, clients, and credit states for each supervisor in the cartera view
- compute fulfilled promoters, totals, and compliance percentage per supervisor
- update the mobile cartera template to consume the calculated metrics directly

## Testing
- php artisan test *(fails: missing vendor autoloader in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d70c75307c8325939382b4ab543886