### PR TITLE
Make recredit contact data optional for promotor mobile form

### DIFF
--- a/app/Http/Controllers/PromotorController.php
+++ b/app/Http/Controllers/PromotorController.php
@@ -385,12 +385,13 @@ class PromotorController extends Controller
             'CURP' => 'required|string|size:18|exists:clientes,CURP',
             'monto' => 'required|numeric|min:0|max:20000',
             'r_newAval' => 'required|boolean',
-            'contacto.calle' => 'required|string|max:255',
-            'contacto.numero_ext' => 'required|string|max:25',
+            'contacto' => 'nullable|array',
+            'contacto.calle' => 'nullable|string|max:255',
+            'contacto.numero_ext' => 'nullable|string|max:25',
             'contacto.numero_int' => 'nullable|string|max:25',
-            'contacto.colonia' => 'required|string|max:255',
-            'contacto.municipio' => 'required|string|max:255',
-            'contacto.cp' => 'required|string|max:10',
+            'contacto.colonia' => 'nullable|string|max:255',
+            'contacto.municipio' => 'nullable|string|max:255',
+            'contacto.cp' => 'nullable|string|max:10',
         ];
 
         if ($isNewAval) {
@@ -467,7 +468,7 @@ class PromotorController extends Controller
                     'aval' => [
                         'curp' => $avalCurp ?? '',
                     ],
-                    'contacto' => $data['contacto'],
+                    'contacto' => $data['contacto'] ?? [],
                     'credito' => [
                         'fecha_inicio' => Carbon::now()->toDateString(),
                     ],


### PR DESCRIPTION
## Summary
- allow promotor recredit validations to treat contacto fields as optional
- fall back to an empty contacto payload when none is provided so filters run consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d715143e2083258db642063f74ad6d