### PR TITLE
Normalize login email case during authentication

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Auth\LoginRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 
 class AuthenticatedSessionController extends Controller
@@ -23,28 +24,33 @@ class AuthenticatedSessionController extends Controller
      * Handle an incoming authentication request.
      */
     public function store(Request $request): RedirectResponse
-{
-    $request->validate([
-        'email' => ['required', 'string', 'email'],
-        'password' => ['required', 'string'],
-    ]);
+    {
+        $request->validate([
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+        ]);
 
-    if (Auth::attempt($request->only('email', 'password'), $request->boolean('remember'))) {
-        $request->session()->regenerate();
+        $credentials = [
+            'email' => Str::lower($request->input('email')),
+            'password' => $request->input('password'),
+        ];
 
-        // Redirigir todos los roles permitidos a mobile
-        if (Auth::user()->hasAnyRole(['promotor', 'supervisor', 'ejecutivo', 'administrativo', 'superadmin'])) {
-            return redirect()->intended(route('mobile.index'));
+        if (Auth::attempt($credentials, $request->boolean('remember'))) {
+            $request->session()->regenerate();
+
+            // Redirigir todos los roles permitidos a mobile
+            if (Auth::user()->hasAnyRole(['promotor', 'supervisor', 'ejecutivo', 'administrativo', 'superadmin'])) {
+                return redirect()->intended(route('mobile.index'));
+            }
+
+            // fallback (ej. admin u otros roles)
+            return redirect()->intended('/dashboard');
         }
 
-        // fallback (ej. admin u otros roles)
-        return redirect()->intended('/dashboard');
+        return back()->withErrors([
+            'email' => 'Las credenciales no coinciden.',
+        ]);
     }
-
-    return back()->withErrors([
-        'email' => 'Las credenciales no coinciden.',
-    ]);
-}
 
 
 


### PR DESCRIPTION
## Summary
- import Illuminate\Support\Str in the authenticated session controller
- lowercase the provided email before attempting authentication while keeping the existing login flow intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc4fb91be88325ba7bfa0bd8c35a6d